### PR TITLE
Beta

### DIFF
--- a/core/class/propluvia.class.php
+++ b/core/class/propluvia.class.php
@@ -194,7 +194,19 @@ class propluvia extends eqLogic {
     $info->setSubType('string');
     $info->setOrder(6);
     $info->save();
-
+    
+    $info = $this->getCmd(null, 'urlPdf');
+    if (!is_object($info)) {
+      $info = new propluviaCmd();
+      $info->setName(__('Url arrêté en pdf', __FILE__));
+    }
+    $info->setLogicalId('urlPdf');
+    $info->setEqLogic_id($this->getId());
+    $info->setType('info');
+    $info->setSubType('string');
+    $info->setOrder(20);
+    $info->save();
+    
     //commandes pour la zone d'eau superficielle
     if ($typeRestriction == 'sup' || $typeRestriction == 'all') {
       $info = $this->getCmd(null, 'id_zone_sup');		//----> ne sert pas, à suprimer pour la stable
@@ -446,8 +458,8 @@ class propluvia extends eqLogic {
         $this->checkAndUpdateCmd('niveau_restriction_sou', 0);
         $this->checkAndUpdateCmd('nom_restriction_sou', '');      
         $this->checkAndUpdateCmd('editorial_zone_sou', '');
-        $this->setConfiguration('urlPdf', '')->save();
-
+        $this->checkAndUpdateCmd('urlPdf', '');
+        
       } else {
         $codeInseeDepartement = $jsonData[0]['codeInseeDepartement'];
         $dateDebutValiditeArrete = date("d/m/Y",strtotime($jsonData[0]['dateDebutValiditeArrete']));
@@ -464,15 +476,14 @@ class propluvia extends eqLogic {
         log::add(__CLASS__, 'debug', 'Commune                : '.$nomCommune);
         log::add(__CLASS__, 'debug', 'url pdf arrêté         : '.$urlPdf);
 
-
         $this->checkAndUpdateCmd('departement', $codeInseeDepartement);
         $this->checkAndUpdateCmd('numero_arrete', $numeroArrete);
         $this->checkAndUpdateCmd('id_arrete', $idArrete);
         $this->checkAndUpdateCmd('date_debut', $dateDebutValiditeArrete);
         $this->checkAndUpdateCmd('date_fin', $dateFinValiditeArrete);
         $this->checkAndUpdateCmd('commune', $nomCommune);
-        $this->setConfiguration('urlPdf', $urlPdf)->save();
-        
+        $this->checkAndUpdateCmd('urlPdf', $urlPdf);
+                
         //effacement des commandes zones avant mise à jour
       /*$this->checkAndUpdateCmd('id_zone_sup', '');
         $this->checkAndUpdateCmd('nom_zone_sup', 'Aucune zone SUP trouvée');
@@ -625,8 +636,8 @@ class propluvia extends eqLogic {
     }    
     $lastActuPropluvia = $this->getConfiguration('lastActuPropluvia','');
     $replace['#lastActuPropluvia#'] = 'Données PROPLUVIA importées le '.date('d/m/Y à H:i:s', $lastActuPropluvia);
-    $urlPdf = $this->getConfiguration('urlPdf','');
-    $replace['#urlPdf#'] = $urlPdf;
+    //$urlPdf = $this->getConfiguration('urlPdf','');
+    //$replace['#urlPdf#'] = $urlPdf;
 
     /* plusieurs lignes séparées pour comprendre */
     if ($typeRestriction == 'sup') {

--- a/core/template/css/propluvia.dashboard.css
+++ b/core/template/css/propluvia.dashboard.css
@@ -26,8 +26,11 @@
 	.tableau td {
 		padding:2px;
      	background-color: #C9EBF8 !important;
-      	
+    	}
+	.fa-mixer{
+   		color: black;
 	}
-.fa-mixer{
-   color: black;
-}
+    .lien-arrete {
+        color: black;
+        text-decoration: underline;
+    }

--- a/core/template/dashboard/propluvia_all.template.html
+++ b/core/template/dashboard/propluvia_all.template.html
@@ -20,8 +20,19 @@
       	<td>Commune : #commune# (#departement#)</td>
 	</tr>
 	<tr>
-      	<td><i class='fas fa-pen'></i></td>
-		<td>Arrêté : n° <a href="#urlPdf#">#numero_arrete#</a></td>
+		<td><i class='fas fa-pen'></i></td>
+		<td id="arreteCell">
+			<script>
+				var urlPdf = "#urlPdf#";
+				var numeroArrete = "#numero_arrete#";
+
+				if (urlPdf !== '') {
+					document.getElementById("arreteCell").innerHTML = "Arrêté : n° <a href='" + urlPdf + "' target='_blank' class='lien-arrete'>" + numeroArrete + "</a>";
+				} else {
+					document.getElementById("arreteCell").innerHTML = "Arrêté : " + numeroArrete;
+				}
+			</script>
+		</td>
 	</tr>
     <tr>
       	<td><i class='fas fa-angle-right'></i></td>

--- a/core/template/dashboard/propluvia_sou.template.html
+++ b/core/template/dashboard/propluvia_sou.template.html
@@ -21,7 +21,18 @@
 	</tr>
 	<tr>
       	<td><i class='fas fa-pen'></i></td>
-		<td>Arrêté : n° <a href="#urlPdf#">#numero_arrete#</a></td>
+        <td id="arreteCell">
+            <script>
+                var urlPdf = "#urlPdf#";
+                var numeroArrete = "#numero_arrete#";
+
+                if (urlPdf !== '') {
+            		document.getElementById("arreteCell").innerHTML = "Arrêté : n° <a href='" + urlPdf + "' target='_blank' class='lien-arrete'>" + numeroArrete + "</a>";
+                } else {
+                    document.getElementById("arreteCell").innerHTML = "Arrêté : " + numeroArrete;
+                }
+            </script>
+        </td>	
 	</tr>
     <tr>
       	<td><i class='fas fa-angle-right'></i></td>

--- a/core/template/dashboard/propluvia_sup.template.html
+++ b/core/template/dashboard/propluvia_sup.template.html
@@ -21,7 +21,18 @@
 	</tr>
 	<tr>
       	<td><i class='fas fa-pen'></i></td>
-		<td>Arrêté : n° <a href="#urlPdf#">#numero_arrete#</a></td>
+        <td id="arreteCell">
+            <script>
+                var urlPdf = "#urlPdf#";
+                var numeroArrete = "#numero_arrete#";
+
+                if (urlPdf !== '') {
+            		document.getElementById("arreteCell").innerHTML = "Arrêté : n° <a href='" + urlPdf + "' target='_blank' class='lien-arrete'>" + numeroArrete + "</a>";
+                } else {
+                    document.getElementById("arreteCell").innerHTML = "Arrêté : " + numeroArrete;
+                }
+            </script>
+        </td>
 	</tr>
     <tr>
       	<td><i class='fas fa-angle-right'></i></td>


### PR DESCRIPTION
modification affichage du lien hypertexte "PDF arrêté" 
- le lien est maintenant contenu dans la commande info "Url arrêté en pdf"
- dans le widget si pas d'arrêté valide, pas de lien généré
- ouverture du lien dans une nouvelle fenêtre ou onglet
- ajout classe CSS pour modifier la couleur d'affichage du lien (ne marche pas à ce jour)