### PR TITLE
feat: migrate plugin to Vigieau API

### DIFF
--- a/core/ajax/propluvia.ajax.php
+++ b/core/ajax/propluvia.ajax.php
@@ -29,9 +29,22 @@ try {
   */
     ajax::init();
 
-
-
-    throw new Exception(__('Aucune méthode correspondante à', __FILE__) . ' : ' . init('action'));
+    switch (init('action')) {
+      case 'getUsageOptions':
+        $eqId = init('id');
+        if (empty($eqId)) {
+          throw new Exception(__('Identifiant d\'équipement manquant', __FILE__));
+        }
+        $eqLogic = propluvia::byId($eqId);
+        if (!is_object($eqLogic)) {
+          throw new Exception(__('Équipement introuvable', __FILE__));
+        }
+        $options = $eqLogic->getUsageOptionsForConfig();
+        ajax::success($options);
+        break;
+      default:
+        throw new Exception(__('Aucune méthode correspondante à', __FILE__) . ' : ' . init('action'));
+    }
     /*     * *********Catch exeption*************** */
 }
 catch (Exception $e) {

--- a/core/class/propluvia.class.php
+++ b/core/class/propluvia.class.php
@@ -265,6 +265,56 @@ class propluvia extends eqLogic {
     return trim($fallback, '_');
   }
 
+  private function normalizeTypeInfo($typeInfo) {
+    $value = trim((string) $typeInfo);
+    if ($value === '') {
+      return '';
+    }
+    $normalized = @iconv('UTF-8', 'ASCII//TRANSLIT//IGNORE', $value);
+    if ($normalized !== false && $normalized !== null) {
+      $value = $normalized;
+    }
+    $value = strtolower($value);
+    $value = str_replace(array(' ', '-'), '_', $value);
+    switch ($value) {
+      case 'part':
+      case 'particulier':
+        return 'particulier';
+      case 'pro':
+      case 'professionnel':
+      case 'entreprise':
+        return 'entreprise';
+      case 'collectivite':
+      case 'collectivites':
+        return 'collectivites';
+      case 'exploitation':
+      case 'exploitation_agricole':
+      case 'exploitationagricole':
+      case 'agricole':
+        return 'exploitation_agricole';
+      case 'all':
+      case 'tout':
+        return '';
+      default:
+        return '';
+    }
+  }
+
+  private function getAudienceFieldForType($typeInfo) {
+    switch ($typeInfo) {
+      case 'particulier':
+        return 'concerneParticulier';
+      case 'entreprise':
+        return 'concerneEntreprise';
+      case 'collectivites':
+        return 'concerneCollectivite';
+      case 'exploitation_agricole':
+        return 'concerneExploitation';
+      default:
+        return '';
+    }
+  }
+
   public function getUsageOptionsForConfig() {
     $usageMap = array();
     $usageCommands = array('usages_zone_sup', 'usages_zone_sou', 'usages_zone_aep');
@@ -705,7 +755,8 @@ class propluvia extends eqLogic {
     $date = date('Y-m-d');
 	$dateFormat = date('d/m/Y');
     $codeInseeCommune = $this->getConfiguration('codeInseeCommune');
-    $typeInfo = $this->getConfiguration('typeInfo');
+    $typeInfoRaw = $this->getConfiguration('typeInfo');
+    $typeInfo = $this->normalizeTypeInfo($typeInfoRaw);
     $typeRestriction = $this->getConfiguration('typeRestriction');
     $eqName = $this->getName();
     log::add(__CLASS__, 'debug', ' ');
@@ -735,13 +786,14 @@ class propluvia extends eqLogic {
 
     //récupération info zones Vigieau
     $profil = '';
-    switch ($typeInfo) {
-      case 'part':
-        $profil = 'particulier';
-        break;
-      case 'pro':
-        $profil = 'professionnel';
-        break;
+    $profilMapping = array(
+      'particulier' => 'particulier',
+      'entreprise' => 'entreprise',
+      'collectivites' => 'collectivites',
+      'exploitation_agricole' => 'exploitation_agricole',
+    );
+    if (isset($profilMapping[$typeInfo])) {
+      $profil = $profilMapping[$typeInfo];
     }
     $url = 'https://api.vigieau.beta.gouv.fr/api/zones?commune='.$codeInseeCommune;
     if ($profil !== '') {
@@ -792,8 +844,9 @@ class propluvia extends eqLogic {
         );
 
         $enabledUsageKeys = $this->getEnabledUsageKeys();
+        $audienceField = $this->getAudienceFieldForType($typeInfo);
         $self = $this;
-        $buildEditorial = function ($usages) use ($typeInfo, $enabledUsageKeys, $self) {
+        $buildEditorial = function ($usages) use ($enabledUsageKeys, $self, $audienceField) {
           $messages = array();
           foreach ($usages as $usage) {
             if (!is_array($usage)) {
@@ -805,17 +858,10 @@ class propluvia extends eqLogic {
                 continue;
               }
             }
-            $shouldAdd = false;
-            switch ($typeInfo) {
-              case 'part':
-                $shouldAdd = isset($usage['concerneParticulier']) ? $usage['concerneParticulier'] : false;
-                break;
-              case 'pro':
-                $shouldAdd = isset($usage['concerneEntreprise']) ? $usage['concerneEntreprise'] : false;
-                break;
-              default:
-                $shouldAdd = true;
-                break;
+            $shouldAdd = true;
+            if ($audienceField !== '') {
+              $audienceValue = isset($usage[$audienceField]) ? $usage[$audienceField] : false;
+              $shouldAdd = ($audienceValue === true || $audienceValue === 1 || $audienceValue === '1' || $audienceValue === 'true');
             }
             if (!$shouldAdd) {
               continue;

--- a/core/class/propluvia.class.php
+++ b/core/class/propluvia.class.php
@@ -122,220 +122,18 @@ class propluvia extends eqLogic {
   public function postSave() {
     $typeRestriction = $this->getConfiguration('typeRestriction');
 
-    $info = $this->getCmd(null, 'departement');
-    if (!is_object($info)) {
-      $info = new propluviaCmd();
-      $info->setName(__('Département', __FILE__));
+    foreach ($this->getCommonCommandDefinitions() as $logicalId => $definition) {
+      $this->createOrUpdateInfoCommand($logicalId, $definition);
     }
-    $info->setLogicalId('departement');
-    $info->setEqLogic_id($this->getId());
-    $info->setType('info');
-    $info->setSubType('string');
-    $info->setOrder(1);
-    $info->save();
 
-    $info = $this->getCmd(null, 'commune');
-    if (!is_object($info)) {
-      $info = new propluviaCmd();
-      $info->setName(__('Commune', __FILE__));
-    }
-    $info->setLogicalId('commune');
-    $info->setEqLogic_id($this->getId());
-    $info->setType('info');
-    $info->setSubType('string');
-    $info->setOrder(2);
-    $info->save();
-
-    $info = $this->getCmd(null, 'numero_arrete');
-    if (!is_object($info)) {
-      $info = new propluviaCmd();
-      $info->setName(__('Numéro arrêté', __FILE__));
-    }
-    $info->setLogicalId('numero_arrete');
-    $info->setEqLogic_id($this->getId());
-    $info->setType('info');
-    $info->setSubType('string');
-    $info->setOrder(4);
-    $info->save();
-  
-    $info = $this->getCmd(null, 'date_debut');
-    if (!is_object($info)) {
-      $info = new propluviaCmd();
-      $info->setName(__('Date début arrêté', __FILE__));
-    }
-    $info->setLogicalId('date_debut');
-    $info->setEqLogic_id($this->getId());
-    $info->setType('info');
-    $info->setSubType('string');
-    $info->setOrder(5);
-    $info->save();
-
-    $info = $this->getCmd(null, 'date_fin');
-    if (!is_object($info)) {
-      $info = new propluviaCmd();
-      $info->setName(__('Date fin arrêté', __FILE__));
-    }
-    $info->setLogicalId('date_fin');
-    $info->setEqLogic_id($this->getId());
-    $info->setType('info');
-    $info->setSubType('string');
-    $info->setOrder(6);
-    $info->save();
-    
-    $info = $this->getCmd(null, 'urlPdf');
-    if (!is_object($info)) {
-      $info = new propluviaCmd();
-      $info->setName(__('Url arrêté en pdf', __FILE__));
-    }
-    $info->setLogicalId('urlPdf');
-    $info->setEqLogic_id($this->getId());
-    $info->setType('info');
-    $info->setSubType('string');
-    $info->setOrder(7);
-    $info->save();
-    
-    //commandes pour la zone d'eau superficielle
-    if ($typeRestriction == 'sup' || $typeRestriction == 'all') {
-      $info = $this->getCmd(null, 'nom_zone_sup');
-      if (!is_object($info)) {
-        $info = new propluviaCmd();
-        $info->setName(__('Nom zone SUP', __FILE__));
-      }
-      $info->setLogicalId('nom_zone_sup');
-      $info->setEqLogic_id($this->getId());
-      $info->setType('info');
-      $info->setSubType('string');
-      $info->setOrder(8);
-      $info->save();
-
-      $info = $this->getCmd(null, 'nom_restriction_sup');
-      if (!is_object($info)) {
-        $info = new propluviaCmd();
-        $info->setName(__('Nom restriction zone SUP', __FILE__));
-      }
-      $info->setLogicalId('nom_restriction_sup');
-      $info->setEqLogic_id($this->getId());
-      $info->setType('info');
-      $info->setSubType('string');
-      $info->setOrder(9);
-      $info->save();
-
-      $info = $this->getCmd(null, 'niveau_restriction_sup');
-      if (!is_object($info)) {
-        $info = new propluviaCmd();
-        $info->setName(__('Niveau restriction zone SUP', __FILE__));
-      }
-      $info->setLogicalId('niveau_restriction_sup');
-      $info->setEqLogic_id($this->getId());
-      $info->setType('info');
-      $info->setSubType('numeric');
-      $info->setOrder(10);
-      $info->save();
-
-      $info = $this->getCmd(null, 'editorial_zone_sup');
-      if (!is_object($info)) {
-        $info = new propluviaCmd();
-        $info->setName(__('Editorial zone SUP', __FILE__));
-      }
-      $info->setLogicalId('editorial_zone_sup');
-      $info->setEqLogic_id($this->getId());
-      $info->setType('info');
-      $info->setSubType('string');
-      $info->setOrder(11);
-      $info->save();
-      
-	  if ($typeRestriction == 'sup') {
-        $info = $this->getCmd(null, 'nom_zone_sou');
-        if (is_object($info)) {
-          $info->remove();
-        }
-
-        $info = $this->getCmd(null, 'nom_restriction_sou');
-        if (is_object($info)) {
-          $info->remove();
-        }
-
-        $info = $this->getCmd(null, 'niveau_restriction_sou');
-        if (is_object($info)) {
-          $info->remove();
-        }
-
-        $info = $this->getCmd(null, 'editorial_zone_sou');
-        if (is_object($info)) {
-          $info->remove();
-        }
-      }
-    }
-  
-    //commandes pour la zone d'eau souterraine
-    if ($typeRestriction == 'sou' || $typeRestriction == 'all') {
-      $info = $this->getCmd(null, 'nom_zone_sou');
-      if (!is_object($info)) {
-        $info = new propluviaCmd();
-        $info->setName(__('Nom zone SOU', __FILE__));
-      }
-      $info->setLogicalId('nom_zone_sou');
-      $info->setEqLogic_id($this->getId());
-      $info->setType('info');
-      $info->setSubType('string');
-      $info->setOrder(12);
-      $info->save();
-
-      $info = $this->getCmd(null, 'nom_restriction_sou');
-      if (!is_object($info)) {
-        $info = new propluviaCmd();
-        $info->setName(__('Nom restriction zone SOU', __FILE__));
-      }
-      $info->setLogicalId('nom_restriction_sou');
-      $info->setEqLogic_id($this->getId());
-      $info->setType('info');
-      $info->setSubType('string');
-      $info->setOrder(13);
-      $info->save();
-
-      $info = $this->getCmd(null, 'niveau_restriction_sou');
-      if (!is_object($info)) {
-        $info = new propluviaCmd();
-        $info->setName(__('Niveau restriction zone SOU', __FILE__));
-      }
-      $info->setLogicalId('niveau_restriction_sou');
-      $info->setEqLogic_id($this->getId());
-      $info->setType('info');
-      $info->setSubType('numeric');
-      $info->setOrder(14);
-      $info->save();
-
-      $info = $this->getCmd(null, 'editorial_zone_sou');
-      if (!is_object($info)) {
-        $info = new propluviaCmd();
-        $info->setName(__('Editorial zone SOU', __FILE__));
-      }
-      $info->setLogicalId('editorial_zone_sou');
-      $info->setEqLogic_id($this->getId());
-      $info->setType('info');
-      $info->setSubType('string');
-      $info->setOrder(15);
-      $info->save();
-    	  
-      if ($typeRestriction == 'sou') {
-        $info = $this->getCmd(null, 'nom_zone_sup');
-        if (is_object($info)) {
-          $info->remove();
-        }
-
-        $info = $this->getCmd(null, 'nom_restriction_sup');
-        if (is_object($info)) {
-          $info->remove();
-        }
-
-        $info = $this->getCmd(null, 'niveau_restriction_sup');
-        if (is_object($info)) {
-          $info->remove();
-        }
-
-        $info = $this->getCmd(null, 'editorial_zone_sup');
-        if (is_object($info)) {
-          $info->remove();
+    $zoneCommandDefinitions = $this->getZoneCommandDefinitions();
+    foreach ($zoneCommandDefinitions as $zoneType => $commands) {
+      $shouldCreate = $this->shouldBuildZoneCommands($zoneType, $typeRestriction);
+      foreach ($commands as $logicalId => $definition) {
+        if ($shouldCreate) {
+          $this->createOrUpdateInfoCommand($logicalId, $definition);
+        } else {
+          $this->removeInfoCommand($logicalId);
         }
       }
     }
@@ -351,6 +149,428 @@ class propluvia extends eqLogic {
     $refresh->setSubType('other');
     $refresh->setOrder(99);
     $refresh->save();
+  }
+
+  private function createOrUpdateInfoCommand($logicalId, $definition) {
+    $cmd = $this->getCmd(null, $logicalId);
+    if (!is_object($cmd)) {
+      $cmd = new propluviaCmd();
+      $cmd->setLogicalId($logicalId);
+      $cmd->setEqLogic_id($this->getId());
+      $cmd->setType('info');
+    } else {
+      $cmd->setEqLogic_id($this->getId());
+      $cmd->setLogicalId($logicalId);
+      $cmd->setType('info');
+    }
+    if (isset($definition['name'])) {
+      $cmd->setName($definition['name']);
+    }
+    if (isset($definition['subType'])) {
+      $cmd->setSubType($definition['subType']);
+    }
+    if (isset($definition['order'])) {
+      $cmd->setOrder($definition['order']);
+    }
+    $cmd->save();
+  }
+
+  private function removeInfoCommand($logicalId) {
+    $cmd = $this->getCmd(null, $logicalId);
+    if (is_object($cmd)) {
+      $cmd->remove();
+    }
+  }
+
+  private function updateCommandIfExists($logicalId, $value) {
+    $cmd = $this->getCmd(null, $logicalId);
+    if (is_object($cmd)) {
+      $this->checkAndUpdateCmd($logicalId, $value);
+    }
+  }
+
+  private function getCommonCommandDefinitions() {
+    return array(
+      'departement' => array(
+        'name' => __('Département', __FILE__),
+        'subType' => 'string',
+        'order' => 1,
+        'default' => ''
+      ),
+      'commune' => array(
+        'name' => __('Commune', __FILE__),
+        'subType' => 'string',
+        'order' => 2,
+        'default' => ''
+      ),
+      'numero_arrete' => array(
+        'name' => __('Numéro arrêté', __FILE__),
+        'subType' => 'string',
+        'order' => 4,
+        'default' => __('Non communiqué', __FILE__)
+      ),
+      'date_debut' => array(
+        'name' => __('Date début arrêté', __FILE__),
+        'subType' => 'string',
+        'order' => 5,
+        'default' => ''
+      ),
+      'date_fin' => array(
+        'name' => __('Date fin arrêté', __FILE__),
+        'subType' => 'string',
+        'order' => 6,
+        'default' => ''
+      ),
+      'urlPdf' => array(
+        'name' => __('Url arrêté en pdf', __FILE__),
+        'subType' => 'string',
+        'order' => 7,
+        'default' => ''
+      ),
+      'urlPdfCadre' => array(
+        'name' => __('Url arrêté cadre', __FILE__),
+        'subType' => 'string',
+        'order' => 8,
+        'default' => ''
+      ),
+    );
+  }
+
+  private function getZoneCommandDefinitions() {
+    return array(
+      'SUP' => array(
+        'nom_zone_sup' => array(
+          'name' => __('Nom zone SUP', __FILE__),
+          'subType' => 'string',
+          'order' => 9,
+          'default' => '',
+          'valueKey' => 'nom'
+        ),
+        'nom_restriction_sup' => array(
+          'name' => __('Nom restriction zone SUP', __FILE__),
+          'subType' => 'string',
+          'order' => 10,
+          'default' => '',
+          'valueKey' => 'label'
+        ),
+        'niveau_restriction_sup' => array(
+          'name' => __('Niveau restriction zone SUP', __FILE__),
+          'subType' => 'numeric',
+          'order' => 11,
+          'default' => 0,
+          'valueKey' => 'niveau'
+        ),
+        'editorial_zone_sup' => array(
+          'name' => __('Editorial zone SUP', __FILE__),
+          'subType' => 'string',
+          'order' => 12,
+          'default' => '',
+          'valueKey' => 'editorial'
+        ),
+        'niveau_gravite_sup' => array(
+          'name' => __('Niveau gravité zone SUP', __FILE__),
+          'subType' => 'string',
+          'order' => 13,
+          'default' => '',
+          'valueKey' => 'niveauGravite'
+        ),
+        'id_zone_sup' => array(
+          'name' => __('ID zone SUP', __FILE__),
+          'subType' => 'numeric',
+          'order' => 14,
+          'default' => 0,
+          'valueKey' => 'id'
+        ),
+        'id_sandre_zone_sup' => array(
+          'name' => __('ID Sandre zone SUP', __FILE__),
+          'subType' => 'numeric',
+          'order' => 15,
+          'default' => 0,
+          'valueKey' => 'idSandre'
+        ),
+        'code_zone_sup' => array(
+          'name' => __('Code zone SUP', __FILE__),
+          'subType' => 'string',
+          'order' => 16,
+          'default' => '',
+          'valueKey' => 'code'
+        ),
+        'type_zone_sup' => array(
+          'name' => __('Type zone SUP', __FILE__),
+          'subType' => 'string',
+          'order' => 17,
+          'default' => '',
+          'valueKey' => 'type'
+        ),
+        'ressource_influencee_sup' => array(
+          'name' => __('Ressource influencée zone SUP', __FILE__),
+          'subType' => 'binary',
+          'order' => 18,
+          'default' => 0,
+          'valueKey' => 'ressourceInfluencee'
+        ),
+        'usages_zone_sup' => array(
+          'name' => __('Usages zone SUP', __FILE__),
+          'subType' => 'string',
+          'order' => 19,
+          'default' => '[]',
+          'valueKey' => 'usages'
+        ),
+        'gid_zone_sup' => array(
+          'name' => __('GID zone SUP', __FILE__),
+          'subType' => 'numeric',
+          'order' => 20,
+          'default' => 0,
+          'valueKey' => 'gid'
+        ),
+        'cdzas_zone_sup' => array(
+          'name' => __('Code ZAS zone SUP', __FILE__),
+          'subType' => 'string',
+          'order' => 21,
+          'default' => '',
+          'valueKey' => 'CdZAS'
+        ),
+        'lbzas_zone_sup' => array(
+          'name' => __('Libellé ZAS zone SUP', __FILE__),
+          'subType' => 'string',
+          'order' => 22,
+          'default' => '',
+          'valueKey' => 'LbZAS'
+        ),
+        'typezas_zone_sup' => array(
+          'name' => __('Type ZAS zone SUP', __FILE__),
+          'subType' => 'string',
+          'order' => 23,
+          'default' => '',
+          'valueKey' => 'TypeZAS'
+        ),
+      ),
+      'SOU' => array(
+        'nom_zone_sou' => array(
+          'name' => __('Nom zone SOU', __FILE__),
+          'subType' => 'string',
+          'order' => 24,
+          'default' => '',
+          'valueKey' => 'nom'
+        ),
+        'nom_restriction_sou' => array(
+          'name' => __('Nom restriction zone SOU', __FILE__),
+          'subType' => 'string',
+          'order' => 25,
+          'default' => '',
+          'valueKey' => 'label'
+        ),
+        'niveau_restriction_sou' => array(
+          'name' => __('Niveau restriction zone SOU', __FILE__),
+          'subType' => 'numeric',
+          'order' => 26,
+          'default' => 0,
+          'valueKey' => 'niveau'
+        ),
+        'editorial_zone_sou' => array(
+          'name' => __('Editorial zone SOU', __FILE__),
+          'subType' => 'string',
+          'order' => 27,
+          'default' => '',
+          'valueKey' => 'editorial'
+        ),
+        'niveau_gravite_sou' => array(
+          'name' => __('Niveau gravité zone SOU', __FILE__),
+          'subType' => 'string',
+          'order' => 28,
+          'default' => '',
+          'valueKey' => 'niveauGravite'
+        ),
+        'id_zone_sou' => array(
+          'name' => __('ID zone SOU', __FILE__),
+          'subType' => 'numeric',
+          'order' => 29,
+          'default' => 0,
+          'valueKey' => 'id'
+        ),
+        'id_sandre_zone_sou' => array(
+          'name' => __('ID Sandre zone SOU', __FILE__),
+          'subType' => 'numeric',
+          'order' => 30,
+          'default' => 0,
+          'valueKey' => 'idSandre'
+        ),
+        'code_zone_sou' => array(
+          'name' => __('Code zone SOU', __FILE__),
+          'subType' => 'string',
+          'order' => 31,
+          'default' => '',
+          'valueKey' => 'code'
+        ),
+        'type_zone_sou' => array(
+          'name' => __('Type zone SOU', __FILE__),
+          'subType' => 'string',
+          'order' => 32,
+          'default' => '',
+          'valueKey' => 'type'
+        ),
+        'ressource_influencee_sou' => array(
+          'name' => __('Ressource influencée zone SOU', __FILE__),
+          'subType' => 'binary',
+          'order' => 33,
+          'default' => 0,
+          'valueKey' => 'ressourceInfluencee'
+        ),
+        'usages_zone_sou' => array(
+          'name' => __('Usages zone SOU', __FILE__),
+          'subType' => 'string',
+          'order' => 34,
+          'default' => '[]',
+          'valueKey' => 'usages'
+        ),
+        'gid_zone_sou' => array(
+          'name' => __('GID zone SOU', __FILE__),
+          'subType' => 'numeric',
+          'order' => 35,
+          'default' => 0,
+          'valueKey' => 'gid'
+        ),
+        'cdzas_zone_sou' => array(
+          'name' => __('Code ZAS zone SOU', __FILE__),
+          'subType' => 'string',
+          'order' => 36,
+          'default' => '',
+          'valueKey' => 'CdZAS'
+        ),
+        'lbzas_zone_sou' => array(
+          'name' => __('Libellé ZAS zone SOU', __FILE__),
+          'subType' => 'string',
+          'order' => 37,
+          'default' => '',
+          'valueKey' => 'LbZAS'
+        ),
+        'typezas_zone_sou' => array(
+          'name' => __('Type ZAS zone SOU', __FILE__),
+          'subType' => 'string',
+          'order' => 38,
+          'default' => '',
+          'valueKey' => 'TypeZAS'
+        ),
+      ),
+      'AEP' => array(
+        'nom_zone_aep' => array(
+          'name' => __('Nom zone AEP', __FILE__),
+          'subType' => 'string',
+          'order' => 39,
+          'default' => '',
+          'valueKey' => 'nom'
+        ),
+        'nom_restriction_aep' => array(
+          'name' => __('Nom restriction zone AEP', __FILE__),
+          'subType' => 'string',
+          'order' => 40,
+          'default' => '',
+          'valueKey' => 'label'
+        ),
+        'niveau_restriction_aep' => array(
+          'name' => __('Niveau restriction zone AEP', __FILE__),
+          'subType' => 'numeric',
+          'order' => 41,
+          'default' => 0,
+          'valueKey' => 'niveau'
+        ),
+        'editorial_zone_aep' => array(
+          'name' => __('Editorial zone AEP', __FILE__),
+          'subType' => 'string',
+          'order' => 42,
+          'default' => '',
+          'valueKey' => 'editorial'
+        ),
+        'niveau_gravite_aep' => array(
+          'name' => __('Niveau gravité zone AEP', __FILE__),
+          'subType' => 'string',
+          'order' => 43,
+          'default' => '',
+          'valueKey' => 'niveauGravite'
+        ),
+        'id_zone_aep' => array(
+          'name' => __('ID zone AEP', __FILE__),
+          'subType' => 'numeric',
+          'order' => 44,
+          'default' => 0,
+          'valueKey' => 'id'
+        ),
+        'id_sandre_zone_aep' => array(
+          'name' => __('ID Sandre zone AEP', __FILE__),
+          'subType' => 'numeric',
+          'order' => 45,
+          'default' => 0,
+          'valueKey' => 'idSandre'
+        ),
+        'code_zone_aep' => array(
+          'name' => __('Code zone AEP', __FILE__),
+          'subType' => 'string',
+          'order' => 46,
+          'default' => '',
+          'valueKey' => 'code'
+        ),
+        'type_zone_aep' => array(
+          'name' => __('Type zone AEP', __FILE__),
+          'subType' => 'string',
+          'order' => 47,
+          'default' => '',
+          'valueKey' => 'type'
+        ),
+        'ressource_influencee_aep' => array(
+          'name' => __('Ressource influencée zone AEP', __FILE__),
+          'subType' => 'binary',
+          'order' => 48,
+          'default' => 0,
+          'valueKey' => 'ressourceInfluencee'
+        ),
+        'usages_zone_aep' => array(
+          'name' => __('Usages zone AEP', __FILE__),
+          'subType' => 'string',
+          'order' => 49,
+          'default' => '[]',
+          'valueKey' => 'usages'
+        ),
+        'gid_zone_aep' => array(
+          'name' => __('GID zone AEP', __FILE__),
+          'subType' => 'numeric',
+          'order' => 50,
+          'default' => 0,
+          'valueKey' => 'gid'
+        ),
+        'cdzas_zone_aep' => array(
+          'name' => __('Code ZAS zone AEP', __FILE__),
+          'subType' => 'string',
+          'order' => 51,
+          'default' => '',
+          'valueKey' => 'CdZAS'
+        ),
+        'lbzas_zone_aep' => array(
+          'name' => __('Libellé ZAS zone AEP', __FILE__),
+          'subType' => 'string',
+          'order' => 52,
+          'default' => '',
+          'valueKey' => 'LbZAS'
+        ),
+        'typezas_zone_aep' => array(
+          'name' => __('Type ZAS zone AEP', __FILE__),
+          'subType' => 'string',
+          'order' => 53,
+          'default' => '',
+          'valueKey' => 'TypeZAS'
+        ),
+      ),
+    );
+  }
+
+  private function shouldBuildZoneCommands($zoneType, $typeRestriction) {
+    switch ($zoneType) {
+      case 'SUP':
+        return in_array($typeRestriction, array('sup', 'all'));
+      case 'SOU':
+        return in_array($typeRestriction, array('sou', 'all'));
+      default:
+        return true;
+    }
   }
 
   public function pullpropluvia() {
@@ -420,20 +640,19 @@ class propluvia extends eqLogic {
       if (count($jsonData) === 0) {
         log::add(__CLASS__, 'info', 'Aucune donnée trouvée à la date du '.$dateFormat. ' pour la commune '.$nomCommune);
 
-        $this->checkAndUpdateCmd('departement', substr($codeInseeCommune, 0, 2));
-        $this->checkAndUpdateCmd('numero_arrete', 'Aucun arrêté trouvé à la date du '.$dateFormat);
-        $this->checkAndUpdateCmd('date_debut', '');
-        $this->checkAndUpdateCmd('date_fin', '');
-        $this->checkAndUpdateCmd('commune', $nomCommune);
-        $this->checkAndUpdateCmd('nom_zone_sup', '');
-        $this->checkAndUpdateCmd('niveau_restriction_sup', 0);
-        $this->checkAndUpdateCmd('nom_restriction_sup', '');
-        $this->checkAndUpdateCmd('editorial_zone_sup', '');
-        $this->checkAndUpdateCmd('nom_zone_sou', '');
-        $this->checkAndUpdateCmd('niveau_restriction_sou', 0);
-        $this->checkAndUpdateCmd('nom_restriction_sou', '');
-        $this->checkAndUpdateCmd('editorial_zone_sou', '');
-        $this->checkAndUpdateCmd('urlPdf', '');
+        $this->updateCommandIfExists('departement', substr($codeInseeCommune, 0, 2));
+        $this->updateCommandIfExists('numero_arrete', 'Aucun arrêté trouvé à la date du '.$dateFormat);
+        $this->updateCommandIfExists('date_debut', '');
+        $this->updateCommandIfExists('date_fin', '');
+        $this->updateCommandIfExists('commune', $nomCommune);
+        $this->updateCommandIfExists('urlPdf', '');
+        $this->updateCommandIfExists('urlPdfCadre', '');
+
+        foreach ($this->getZoneCommandDefinitions() as $zoneType => $commands) {
+          foreach ($commands as $logicalId => $definition) {
+            $this->updateCommandIfExists($logicalId, isset($definition['default']) ? $definition['default'] : '');
+          }
+        }
       } else {
         $levelMapping = array(
           'vigilance' => array('label' => __('Vigilance', __FILE__), 'value' => 1),
@@ -483,20 +702,46 @@ class propluvia extends eqLogic {
           return implode('<br/><br/>', $messages);
         };
 
+        $zoneCommandDefinitions = $this->getZoneCommandDefinitions();
+        $zoneValues = array();
+        foreach ($zoneCommandDefinitions as $zoneType => $commands) {
+          $zoneValues[$zoneType] = array(
+            'nom' => '',
+            'niveau' => 0,
+            'label' => '',
+            'editorial' => '',
+            'niveauGravite' => '',
+            'id' => 0,
+            'idSandre' => 0,
+            'code' => '',
+            'type' => '',
+            'ressourceInfluencee' => 0,
+            'usages' => '[]',
+            'gid' => 0,
+            'CdZAS' => '',
+            'LbZAS' => '',
+            'TypeZAS' => '',
+          );
+        }
+
         $codeInseeDepartement = substr($codeInseeCommune, 0, 2);
         $dateDebutValiditeArrete = '';
         $dateFinValiditeArrete = '';
         $numeroArrete = __('Non communiqué', __FILE__);
         $urlPdf = '';
+        $urlPdfCadre = '';
+        $arreteCaptured = false;
 
         foreach ($jsonData as $zone) {
           if (!is_array($zone)) {
             continue;
           }
+
           if (!empty($zone['departement'])) {
             $codeInseeDepartement = $zone['departement'];
           }
-          if (isset($zone['arrete']) && is_array($zone['arrete'])) {
+
+          if (!$arreteCaptured && isset($zone['arrete']) && is_array($zone['arrete'])) {
             $arrete = $zone['arrete'];
             if (!empty($arrete['dateDebutValidite'])) {
               $dateDebutValiditeArrete = date('d/m/Y', strtotime($arrete['dateDebutValidite']));
@@ -510,62 +755,40 @@ class propluvia extends eqLogic {
             if (!empty($arrete['cheminFichier'])) {
               $urlPdf = $arrete['cheminFichier'];
             }
-            break;
+            if (!empty($arrete['cheminFichierArreteCadre'])) {
+              $urlPdfCadre = $arrete['cheminFichierArreteCadre'];
+            }
+            $arreteCaptured = true;
           }
-        }
 
-        log::add(__CLASS__, 'debug', 'Département            : '.$codeInseeDepartement);
-        log::add(__CLASS__, 'debug', 'Numéro arrêté          : '.$numeroArrete);
-        log::add(__CLASS__, 'debug', 'Début validité arrêté  : '.$dateDebutValiditeArrete);
-        log::add(__CLASS__, 'debug', 'Fin validité arrêté    : '.$dateFinValiditeArrete);
-        log::add(__CLASS__, 'debug', 'Commune                : '.$nomCommune);
-        log::add(__CLASS__, 'debug', 'url pdf arrêté         : '.$urlPdf);
-
-        $this->checkAndUpdateCmd('departement', $codeInseeDepartement);
-        $this->checkAndUpdateCmd('numero_arrete', $numeroArrete);
-        $this->checkAndUpdateCmd('date_debut', $dateDebutValiditeArrete);
-        $this->checkAndUpdateCmd('date_fin', $dateFinValiditeArrete);
-        $this->checkAndUpdateCmd('commune', $nomCommune);
-        $this->checkAndUpdateCmd('urlPdf', $urlPdf);
-
-        $zoneValues = array(
-          'SUP' => array(
-            'nom' => '',
-            'niveau' => 0,
-            'label' => '',
-            'editorial' => ''
-          ),
-          'SOU' => array(
-            'nom' => '',
-            'niveau' => 0,
-            'label' => '',
-            'editorial' => ''
-          )
-        );
-
-        foreach ($jsonData as $zone) {
-          if (!is_array($zone)) {
-            continue;
-          }
           $typeZone = isset($zone['type']) ? strtoupper($zone['type']) : '';
           if (!isset($zoneValues[$typeZone])) {
             continue;
           }
+
           $nomZone = isset($zone['nom']) ? $zone['nom'] : '';
-          $niveauGravite = isset($zone['niveauGravite']) ? strtolower($zone['niveauGravite']) : '';
+          $niveauGraviteRaw = isset($zone['niveauGravite']) ? $zone['niveauGravite'] : '';
+          $niveauGraviteKey = strtolower($niveauGraviteRaw);
           $usages = isset($zone['usages']) && is_array($zone['usages']) ? $zone['usages'] : array();
 
           $niveauRestriction = 0;
           $nomNiveau = '';
-          if (isset($levelMapping[$niveauGravite])) {
-            $niveauRestriction = $levelMapping[$niveauGravite]['value'];
-            $nomNiveau = $levelMapping[$niveauGravite]['label'];
-          } elseif ($niveauGravite !== '') {
+          if (isset($levelMapping[$niveauGraviteKey])) {
+            $niveauRestriction = $levelMapping[$niveauGraviteKey]['value'];
+            $nomNiveau = $levelMapping[$niveauGraviteKey]['label'];
+          } elseif ($niveauGraviteRaw !== '') {
             $niveauRestriction = 0;
-            $nomNiveau = ucfirst($niveauGravite);
+            $nomNiveau = ucfirst($niveauGraviteKey);
           }
 
           $editorial = $buildEditorial($usages);
+          $usagesJson = '[]';
+          if (!empty($usages)) {
+            $usagesJsonEncoded = json_encode($usages, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+            if ($usagesJsonEncoded !== false) {
+              $usagesJson = $usagesJsonEncoded;
+            }
+          }
 
           log::add(__CLASS__, 'debug', '----------'.strtoupper($nomZone.' ['.$typeZone.']').'----------');
           log::add(__CLASS__, 'debug', 'Niveau >> '.$nomNiveau.' ('.$niveauRestriction.')');
@@ -576,33 +799,43 @@ class propluvia extends eqLogic {
             'niveau' => $niveauRestriction,
             'label' => $nomNiveau,
             'editorial' => $editorial,
+            'niveauGravite' => $niveauGraviteRaw,
+            'id' => isset($zone['id']) ? intval($zone['id']) : 0,
+            'idSandre' => isset($zone['idSandre']) ? intval($zone['idSandre']) : 0,
+            'code' => isset($zone['code']) ? $zone['code'] : '',
+            'type' => isset($zone['type']) ? $zone['type'] : $typeZone,
+            'ressourceInfluencee' => !empty($zone['ressourceInfluencee']) ? 1 : 0,
+            'usages' => $usagesJson,
+            'gid' => isset($zone['gid']) ? intval($zone['gid']) : 0,
+            'CdZAS' => isset($zone['CdZAS']) ? $zone['CdZAS'] : '',
+            'LbZAS' => isset($zone['LbZAS']) ? $zone['LbZAS'] : '',
+            'TypeZAS' => isset($zone['TypeZAS']) ? $zone['TypeZAS'] : '',
           );
         }
 
-        if ($typeRestriction == 'sup' || $typeRestriction == 'all') {
-          $this->checkAndUpdateCmd('nom_zone_sup', $zoneValues['SUP']['nom']);
-          $this->checkAndUpdateCmd('niveau_restriction_sup', $zoneValues['SUP']['niveau']);
-          $this->checkAndUpdateCmd('nom_restriction_sup', $zoneValues['SUP']['label']);
-          $this->checkAndUpdateCmd('editorial_zone_sup', $zoneValues['SUP']['editorial']);
-        }
-        if ($typeRestriction == 'sou' || $typeRestriction == 'all') {
-          $this->checkAndUpdateCmd('nom_zone_sou', $zoneValues['SOU']['nom']);
-          $this->checkAndUpdateCmd('niveau_restriction_sou', $zoneValues['SOU']['niveau']);
-          $this->checkAndUpdateCmd('nom_restriction_sou', $zoneValues['SOU']['label']);
-          $this->checkAndUpdateCmd('editorial_zone_sou', $zoneValues['SOU']['editorial']);
-        }
+        log::add(__CLASS__, 'debug', 'Département            : '.$codeInseeDepartement);
+        log::add(__CLASS__, 'debug', 'Numéro arrêté          : '.$numeroArrete);
+        log::add(__CLASS__, 'debug', 'Début validité arrêté  : '.$dateDebutValiditeArrete);
+        log::add(__CLASS__, 'debug', 'Fin validité arrêté    : '.$dateFinValiditeArrete);
+        log::add(__CLASS__, 'debug', 'Commune                : '.$nomCommune);
+        log::add(__CLASS__, 'debug', 'url pdf arrêté         : '.$urlPdf);
+        log::add(__CLASS__, 'debug', 'url pdf arrêté cadre   : '.$urlPdfCadre);
 
-        if ($typeRestriction == 'sup') {
-          $this->checkAndUpdateCmd('nom_zone_sou', '');
-          $this->checkAndUpdateCmd('niveau_restriction_sou', 0);
-          $this->checkAndUpdateCmd('nom_restriction_sou', '');
-          $this->checkAndUpdateCmd('editorial_zone_sou', '');
-        }
-        if ($typeRestriction == 'sou') {
-          $this->checkAndUpdateCmd('nom_zone_sup', '');
-          $this->checkAndUpdateCmd('niveau_restriction_sup', 0);
-          $this->checkAndUpdateCmd('nom_restriction_sup', '');
-          $this->checkAndUpdateCmd('editorial_zone_sup', '');
+        $this->updateCommandIfExists('departement', $codeInseeDepartement);
+        $this->updateCommandIfExists('numero_arrete', $numeroArrete);
+        $this->updateCommandIfExists('date_debut', $dateDebutValiditeArrete);
+        $this->updateCommandIfExists('date_fin', $dateFinValiditeArrete);
+        $this->updateCommandIfExists('commune', $nomCommune);
+        $this->updateCommandIfExists('urlPdf', $urlPdf);
+        $this->updateCommandIfExists('urlPdfCadre', $urlPdfCadre);
+
+        foreach ($zoneCommandDefinitions as $zoneType => $commands) {
+          $zoneData = isset($zoneValues[$zoneType]) ? $zoneValues[$zoneType] : array();
+          foreach ($commands as $logicalId => $definition) {
+            $valueKey = isset($definition['valueKey']) ? $definition['valueKey'] : null;
+            $value = $valueKey !== null && isset($zoneData[$valueKey]) ? $zoneData[$valueKey] : (isset($definition['default']) ? $definition['default'] : '');
+            $this->updateCommandIfExists($logicalId, $value);
+          }
         }
       }
     }

--- a/core/class/propluvia.class.php
+++ b/core/class/propluvia.class.php
@@ -796,6 +796,8 @@ class propluvia extends eqLogic {
         return in_array($typeRestriction, array('sup', 'all'));
       case 'SOU':
         return in_array($typeRestriction, array('sou', 'all'));
+      case 'AEP':
+        return in_array($typeRestriction, array('aep', 'all'));
       default:
         return true;
     }
@@ -959,10 +961,10 @@ class propluvia extends eqLogic {
         $codeInseeDepartement = substr($codeInseeCommune, 0, 2);
         $dateDebutValiditeArrete = '';
         $dateFinValiditeArrete = '';
-        $numeroArrete = __('Non communiqué', __FILE__);
+        $defaultNumeroArrete = __('Non communiqué', __FILE__);
+        $numeroArrete = $defaultNumeroArrete;
         $urlPdf = '';
         $urlPdfCadre = '';
-        $arreteCaptured = false;
 
         foreach ($jsonData as $zone) {
           if (!is_array($zone)) {
@@ -973,24 +975,23 @@ class propluvia extends eqLogic {
             $codeInseeDepartement = $zone['departement'];
           }
 
-          if (!$arreteCaptured && isset($zone['arrete']) && is_array($zone['arrete'])) {
+          if (isset($zone['arrete']) && is_array($zone['arrete'])) {
             $arrete = $zone['arrete'];
-            if (!empty($arrete['dateDebutValidite'])) {
+            if ($dateDebutValiditeArrete === '' && !empty($arrete['dateDebutValidite'])) {
               $dateDebutValiditeArrete = date('d/m/Y', strtotime($arrete['dateDebutValidite']));
             }
-            if (!empty($arrete['dateFinValidite'])) {
+            if ($dateFinValiditeArrete === '' && !empty($arrete['dateFinValidite'])) {
               $dateFinValiditeArrete = date('d/m/Y', strtotime($arrete['dateFinValidite']));
             }
-            if (!empty($arrete['id'])) {
+            if ($numeroArrete === $defaultNumeroArrete && !empty($arrete['id'])) {
               $numeroArrete = $arrete['id'];
             }
-            if (!empty($arrete['cheminFichier'])) {
+            if ($urlPdf === '' && !empty($arrete['cheminFichier'])) {
               $urlPdf = $arrete['cheminFichier'];
             }
-            if (!empty($arrete['cheminFichierArreteCadre'])) {
+            if ($urlPdfCadre === '' && !empty($arrete['cheminFichierArreteCadre'])) {
               $urlPdfCadre = $arrete['cheminFichierArreteCadre'];
             }
-            $arreteCaptured = true;
           }
 
           $typeZone = isset($zone['type']) ? strtoupper($zone['type']) : '';
@@ -1161,7 +1162,31 @@ class propluvia extends eqLogic {
           break;
       }
 
-    }    
+      $replace['#nom_restriction_aep_N1#'] = '';
+      $replace['#nom_restriction_aep_N2#'] = '';
+      $replace['#nom_restriction_aep_N3#'] = '';
+      $replace['#nom_restriction_aep_N4#'] = '';
+      $replace['#nom_restriction_aep_N5#'] = '';
+
+      switch ($replace['#niveau_restriction_aep#']) {
+        case 0:
+          $replace['#nom_restriction_aep_N1#'] = '<center><i class="fab fa-mixer"></i></center>';
+          break;
+        case 1:
+          $replace['#nom_restriction_aep_N2#'] = '<center><i class="fab fa-mixer"></i></center>';
+          break;
+        case 3:
+          $replace['#nom_restriction_aep_N3#'] = '<center><i class="fab fa-mixer"></i></center>';
+          break;
+        case 4:
+          $replace['#nom_restriction_aep_N4#'] = '<center><i class="fab fa-mixer"></i></center>';
+          break;
+        case 5:
+          $replace['#nom_restriction_aep_N5#'] = '<center><i class="fab fa-mixer"></i></center>';
+          break;
+      }
+
+    }
     $lastActuPropluvia = $this->getConfiguration('lastActuPropluvia','');
     $replace['#lastActuPropluvia#'] = 'Données PROPLUVIA importées le '.date('d/m/Y à H:i:s', $lastActuPropluvia);
 
@@ -1174,6 +1199,12 @@ class propluvia extends eqLogic {
     }
     if ($typeRestriction == 'sou') {
       $getTemplate = getTemplate('core', $version, 'propluvia_sou.template', __CLASS__); // on récupère le template 'propluvia.template' du plugin.
+      $template_replace = template_replace($replace, $getTemplate); // on remplace les tags
+      $postToHtml = $this->postToHtml($_version,$template_replace); // on met en cache le widget, si la config de l'user le permet.
+      return $postToHtml; // renvoie le code du template du widget.
+    }
+    if ($typeRestriction == 'aep') {
+      $getTemplate = getTemplate('core', $version, 'propluvia_aep.template', __CLASS__); // on récupère le template 'propluvia.template' du plugin.
       $template_replace = template_replace($replace, $getTemplate); // on remplace les tags
       $postToHtml = $this->postToHtml($_version,$template_replace); // on met en cache le widget, si la config de l'user le permet.
       return $postToHtml; // renvoie le code du template du widget.

--- a/core/class/propluvia.class.php
+++ b/core/class/propluvia.class.php
@@ -243,6 +243,28 @@ class propluvia extends eqLogic {
     return '';
   }
 
+  private function buildUsageDisplayKey($usage) {
+    if (!is_array($usage)) {
+      return '';
+    }
+    if (!empty($usage['nom'])) {
+      $slug = $this->slugifyUsageLabel($usage['nom']);
+      if ($slug !== '') {
+        return 'display_nom_'.$slug;
+      }
+    }
+    if (!empty($usage['thematique'])) {
+      $slug = $this->slugifyUsageLabel($usage['thematique']);
+      if ($slug !== '') {
+        return 'display_thematique_'.$slug;
+      }
+    }
+    if (isset($usage['id']) && $usage['id'] !== '' && $usage['id'] !== null) {
+      return 'display_id_'.$usage['id'];
+    }
+    return '';
+  }
+
   private function slugifyUsageLabel($label) {
     $label = trim((string) $label);
     if ($label === '') {
@@ -316,7 +338,7 @@ class propluvia extends eqLogic {
   }
 
   public function getUsageOptionsForConfig() {
-    $usageMap = array();
+    $usageGroups = array();
     $usageCommands = array('usages_zone_sup', 'usages_zone_sou', 'usages_zone_aep');
     foreach ($usageCommands as $logicalId) {
       $cmd = $this->getCmd('info', $logicalId);
@@ -343,20 +365,34 @@ class propluvia extends eqLogic {
         if ($key === '') {
           continue;
         }
-        if (!isset($usageMap[$key])) {
-          $usageMap[$key] = array(
-            'key' => $key,
-            'id' => isset($usage['id']) ? $usage['id'] : '',
+        $displayKey = $this->buildUsageDisplayKey($usage);
+        if ($displayKey === '') {
+          $displayKey = $key;
+        }
+        if (!isset($usageGroups[$displayKey])) {
+          $usageGroups[$displayKey] = array(
+            'displayKey' => $displayKey,
+            'keys' => array(),
             'nom' => isset($usage['nom']) ? $usage['nom'] : '',
             'thematique' => isset($usage['thematique']) ? $usage['thematique'] : '',
           );
+        } else {
+          if ($usageGroups[$displayKey]['nom'] === '' && !empty($usage['nom'])) {
+            $usageGroups[$displayKey]['nom'] = $usage['nom'];
+          }
+          if ($usageGroups[$displayKey]['thematique'] === '' && !empty($usage['thematique'])) {
+            $usageGroups[$displayKey]['thematique'] = $usage['thematique'];
+          }
+        }
+        if (!in_array($key, $usageGroups[$displayKey]['keys'], true)) {
+          $usageGroups[$displayKey]['keys'][] = $key;
         }
       }
     }
-    if (empty($usageMap)) {
+    if (empty($usageGroups)) {
       return array();
     }
-    uasort($usageMap, function ($a, $b) {
+    uasort($usageGroups, function ($a, $b) {
       $themeA = isset($a['thematique']) ? strtolower($a['thematique']) : '';
       $themeB = isset($b['thematique']) ? strtolower($b['thematique']) : '';
       if ($themeA === $themeB) {
@@ -364,7 +400,21 @@ class propluvia extends eqLogic {
       }
       return strcmp($themeA, $themeB);
     });
-    return array_values($usageMap);
+    $options = array();
+    foreach ($usageGroups as $group) {
+      $keys = isset($group['keys']) ? array_values($group['keys']) : array();
+      if (empty($keys)) {
+        continue;
+      }
+      $options[] = array(
+        'displayKey' => isset($group['displayKey']) ? $group['displayKey'] : $keys[0],
+        'keys' => $keys,
+        'key' => $keys[0],
+        'nom' => isset($group['nom']) ? $group['nom'] : '',
+        'thematique' => isset($group['thematique']) ? $group['thematique'] : '',
+      );
+    }
+    return $options;
   }
 
   private function getCommonCommandDefinitions() {

--- a/core/class/propluvia.class.php
+++ b/core/class/propluvia.class.php
@@ -359,12 +359,6 @@ class propluvia extends eqLogic {
     $codeInseeCommune = $this->getConfiguration('codeInseeCommune');
     $typeInfo = $this->getConfiguration('typeInfo');
     $typeRestriction = $this->getConfiguration('typeRestriction');
-    if (!empty($typeInfo)){
-      $typeInfo = '_'.$typeInfo;
-    } else {
-      $typeInfo = '';
-    }
-    $trans = array(" " => "_", "é" => "e", "è" => "e");
     $eqName = $this->getName();
     log::add(__CLASS__, 'debug', ' ');
     log::add(__CLASS__, 'debug', '*********** PROPLUVIA ['.$eqName.'] ***********');
@@ -391,11 +385,23 @@ class propluvia extends eqLogic {
       log::add(__CLASS__, 'error', 'Code INSEE de commune ('.$codeInseeCommune.') invalide');
     }
 
-    //récupération info arrêté
-    $url = 'https://eau.api.agriculture.gouv.fr/apis/propluvia/arretes/'.$date.'/commune/'.$codeInseeCommune;
+    //récupération info zones Vigieau
+    $profil = '';
+    switch ($typeInfo) {
+      case 'part':
+        $profil = 'particulier';
+        break;
+      case 'pro':
+        $profil = 'professionnel';
+        break;
+    }
+    $url = 'https://api.vigieau.beta.gouv.fr/api/zones?commune='.$codeInseeCommune;
+    if ($profil !== '') {
+      $url .= '&profil='.$profil;
+    }
     $ch = curl_init();
-	curl_setopt($ch, CURLOPT_URL, $url);
- 	curl_setopt($ch, CURLOPT_HEADER, false);
+        curl_setopt($ch, CURLOPT_URL, $url);
+        curl_setopt($ch, CURLOPT_HEADER, false);
 	curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
 	curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, 5);   
 	curl_setopt($ch, CURLOPT_TIMEOUT, 15);         
@@ -407,15 +413,13 @@ class propluvia extends eqLogic {
   	$jsonData = json_decode($response, true);  
      
     if(!is_array($jsonData)){
-    	log::add(__CLASS__, 'error', 'le site \'https://eau.api.agriculture.gouv.fr\' renvoie une erreur ou n\'est pas accessible');        
-    } else {      
+        log::add(__CLASS__, 'error', 'le site \'https://api.vigieau.beta.gouv.fr\' renvoie une erreur ou n\'est pas accessible');
+    } else {
       //sauvegarde date et heure de récupérations des info Propluvia
       $this->setConfiguration('lastActuPropluvia', time())->save();
-      //vérifie qu'un arrêté existe
-      if ($jsonData['message'] != NULL) {
-        log::add(__CLASS__, 'info', 'Aucun arrêté trouvé à la date du '.$dateFormat. ' pour la commune '.$nomCommune);
+      if (count($jsonData) === 0) {
+        log::add(__CLASS__, 'info', 'Aucune donnée trouvée à la date du '.$dateFormat. ' pour la commune '.$nomCommune);
 
-        // mise à jour des commandes
         $this->checkAndUpdateCmd('departement', substr($codeInseeCommune, 0, 2));
         $this->checkAndUpdateCmd('numero_arrete', 'Aucun arrêté trouvé à la date du '.$dateFormat);
         $this->checkAndUpdateCmd('date_debut', '');
@@ -423,22 +427,94 @@ class propluvia extends eqLogic {
         $this->checkAndUpdateCmd('commune', $nomCommune);
         $this->checkAndUpdateCmd('nom_zone_sup', '');
         $this->checkAndUpdateCmd('niveau_restriction_sup', 0);
-        $this->checkAndUpdateCmd('nom_restriction_sup', '');      
-        $this->checkAndUpdateCmd('editorial_zone_sup', '');      
+        $this->checkAndUpdateCmd('nom_restriction_sup', '');
+        $this->checkAndUpdateCmd('editorial_zone_sup', '');
         $this->checkAndUpdateCmd('nom_zone_sou', '');
         $this->checkAndUpdateCmd('niveau_restriction_sou', 0);
-        $this->checkAndUpdateCmd('nom_restriction_sou', '');      
+        $this->checkAndUpdateCmd('nom_restriction_sou', '');
         $this->checkAndUpdateCmd('editorial_zone_sou', '');
         $this->checkAndUpdateCmd('urlPdf', '');
-        
       } else {
-        $codeInseeDepartement = $jsonData[0]['codeInseeDepartement'];
-        $dateDebutValiditeArrete = date("d/m/Y",strtotime($jsonData[0]['dateDebutValiditeArrete']));
-        $dateFinValiditeArrete = date("d/m/Y",strtotime($jsonData[0]['dateFinValiditeArrete']));
-        $numeroArrete = $jsonData[0]['numeroArrete'];
-        $urlPdf = 'https://eau.api.agriculture.gouv.fr/apis/propluvia/file/pdf/'.$jsonData[0]['fdCdn'];
-        //mise à jour des commandes et log avec info arrêté
-      	log::add(__CLASS__, 'debug', 'Département            : '.$codeInseeDepartement);
+        $levelMapping = array(
+          'vigilance' => array('label' => __('Vigilance', __FILE__), 'value' => 1),
+          'alerte' => array('label' => __('Alerte', __FILE__), 'value' => 3),
+          'alerte_renforcee' => array('label' => __('Alerte renforcée', __FILE__), 'value' => 4),
+          'crise' => array('label' => __('Crise', __FILE__), 'value' => 5),
+          'crise_renforcee' => array('label' => __('Crise renforcée', __FILE__), 'value' => 5),
+          'aucune' => array('label' => __('Aucune restriction', __FILE__), 'value' => 0),
+        );
+
+        $buildEditorial = function ($usages) use ($typeInfo) {
+          $messages = array();
+          foreach ($usages as $usage) {
+            if (!is_array($usage)) {
+              continue;
+            }
+            $shouldAdd = false;
+            switch ($typeInfo) {
+              case 'part':
+                $shouldAdd = isset($usage['concerneParticulier']) ? $usage['concerneParticulier'] : false;
+                break;
+              case 'pro':
+                $shouldAdd = isset($usage['concerneEntreprise']) ? $usage['concerneEntreprise'] : false;
+                break;
+              default:
+                $shouldAdd = true;
+                break;
+            }
+            if (!$shouldAdd) {
+              continue;
+            }
+            $nomUsage = isset($usage['nom']) ? trim($usage['nom']) : '';
+            $description = isset($usage['description']) ? trim($usage['description']) : '';
+            if ($nomUsage === '' && $description === '') {
+              continue;
+            }
+            $description = str_replace(array("\r\n", "\n", "\r"), '<br/>', $description);
+            if ($nomUsage !== '' && $description !== '') {
+              $messages[] = '<b>'.$nomUsage.'</b> : '.$description;
+            } else {
+              $messages[] = $nomUsage.$description;
+            }
+          }
+          if (count($messages) === 0) {
+            return __('Aucune information disponible', __FILE__);
+          }
+          return implode('<br/><br/>', $messages);
+        };
+
+        $codeInseeDepartement = substr($codeInseeCommune, 0, 2);
+        $dateDebutValiditeArrete = '';
+        $dateFinValiditeArrete = '';
+        $numeroArrete = __('Non communiqué', __FILE__);
+        $urlPdf = '';
+
+        foreach ($jsonData as $zone) {
+          if (!is_array($zone)) {
+            continue;
+          }
+          if (!empty($zone['departement'])) {
+            $codeInseeDepartement = $zone['departement'];
+          }
+          if (isset($zone['arrete']) && is_array($zone['arrete'])) {
+            $arrete = $zone['arrete'];
+            if (!empty($arrete['dateDebutValidite'])) {
+              $dateDebutValiditeArrete = date('d/m/Y', strtotime($arrete['dateDebutValidite']));
+            }
+            if (!empty($arrete['dateFinValidite'])) {
+              $dateFinValiditeArrete = date('d/m/Y', strtotime($arrete['dateFinValidite']));
+            }
+            if (!empty($arrete['id'])) {
+              $numeroArrete = $arrete['id'];
+            }
+            if (!empty($arrete['cheminFichier'])) {
+              $urlPdf = $arrete['cheminFichier'];
+            }
+            break;
+          }
+        }
+
+        log::add(__CLASS__, 'debug', 'Département            : '.$codeInseeDepartement);
         log::add(__CLASS__, 'debug', 'Numéro arrêté          : '.$numeroArrete);
         log::add(__CLASS__, 'debug', 'Début validité arrêté  : '.$dateDebutValiditeArrete);
         log::add(__CLASS__, 'debug', 'Fin validité arrêté    : '.$dateFinValiditeArrete);
@@ -451,58 +527,82 @@ class propluvia extends eqLogic {
         $this->checkAndUpdateCmd('date_fin', $dateFinValiditeArrete);
         $this->checkAndUpdateCmd('commune', $nomCommune);
         $this->checkAndUpdateCmd('urlPdf', $urlPdf);
-                
-       //balayage des zones
-        foreach ($jsonData[0]['restrictions'] as $value=>$jsonKey) {       
-          $niveauRestriction = $jsonKey['niveauRestriction'];
-          $nomNiveau = $jsonKey['nomNiveau'];
-          $nomZone =  $jsonKey['zoneAlerte']['nomZone'];
-          $typeZone = $jsonKey['zoneAlerte']['typeZone'];
 
-          //balayage des communes pour récupérer uniquement info de celle recherchée
-          foreach ($jsonKey['zoneAlerte']['communes'] as $value2=>$jsonKey2) {
-            if ( $jsonKey2['codeInseeCommune'] == $codeInseeCommune) {
-              //recupération info détaillé sur le niveau d'alerte
-              $url_legende = 'https://eau.api.agriculture.gouv.fr/apis/propluvia/editoriaux/?idEditorial=legende_'.strtr(strtolower($nomNiveau),$trans).$typeInfo;   
-              $ch = curl_init();
-              curl_setopt($ch, CURLOPT_URL, $url_legende);
-              curl_setopt($ch, CURLOPT_HEADER, false);
-              curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
-              curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, 5);   
-              curl_setopt($ch, CURLOPT_TIMEOUT, 15);         
-              curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true);
-              curl_setopt($ch, CURLOPT_MAXREDIRS, 1);
-              curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, true);
-              $response = curl_exec($ch);
-              curl_close($ch);
-              $legende = json_decode($response, true);  
-            
-              if(is_array($legende)){
-                  $contenuEditorial = $legende[0]['contenuEditorial'];
-              } else {
-                  $contenuEditorial = 'Aucune information disponible';
-              }
+        $zoneValues = array(
+          'SUP' => array(
+            'nom' => '',
+            'niveau' => 0,
+            'label' => '',
+            'editorial' => ''
+          ),
+          'SOU' => array(
+            'nom' => '',
+            'niveau' => 0,
+            'label' => '',
+            'editorial' => ''
+          )
+        );
 
-              //affichage résultat dans le log
-              log::add(__CLASS__, 'debug', '----------'.strtoupper($nomZone.' ['.$typeZone.']').'----------');
-              log::add(__CLASS__, 'debug', 'Niveau >> '.$nomNiveau.' ('.$niveauRestriction.')');
-              log::add(__CLASS__, 'debug', $contenuEditorial);
-
-              //mise à jour des commmandes
-              if ($typeZone == 'SUP' && ($typeRestriction == 'sup' || $typeRestriction == 'all')) {
-                $this->checkAndUpdateCmd('nom_zone_sup', $nomZone);
-                $this->checkAndUpdateCmd('niveau_restriction_sup', $niveauRestriction);
-                $this->checkAndUpdateCmd('nom_restriction_sup', $nomNiveau);      
-                $this->checkAndUpdateCmd('editorial_zone_sup', $contenuEditorial);
-              }
-              if ($typeZone == 'SOU' && ($typeRestriction == 'sou' || $typeRestriction == 'all')) {
-                $this->checkAndUpdateCmd('nom_zone_sou', $nomZone);
-                $this->checkAndUpdateCmd('niveau_restriction_sou', $niveauRestriction);
-                $this->checkAndUpdateCmd('nom_restriction_sou', $nomNiveau);      
-                $this->checkAndUpdateCmd('editorial_zone_sou', $contenuEditorial);      
-              } 
-            }
+        foreach ($jsonData as $zone) {
+          if (!is_array($zone)) {
+            continue;
           }
+          $typeZone = isset($zone['type']) ? strtoupper($zone['type']) : '';
+          if (!isset($zoneValues[$typeZone])) {
+            continue;
+          }
+          $nomZone = isset($zone['nom']) ? $zone['nom'] : '';
+          $niveauGravite = isset($zone['niveauGravite']) ? strtolower($zone['niveauGravite']) : '';
+          $usages = isset($zone['usages']) && is_array($zone['usages']) ? $zone['usages'] : array();
+
+          $niveauRestriction = 0;
+          $nomNiveau = '';
+          if (isset($levelMapping[$niveauGravite])) {
+            $niveauRestriction = $levelMapping[$niveauGravite]['value'];
+            $nomNiveau = $levelMapping[$niveauGravite]['label'];
+          } elseif ($niveauGravite !== '') {
+            $niveauRestriction = 0;
+            $nomNiveau = ucfirst($niveauGravite);
+          }
+
+          $editorial = $buildEditorial($usages);
+
+          log::add(__CLASS__, 'debug', '----------'.strtoupper($nomZone.' ['.$typeZone.']').'----------');
+          log::add(__CLASS__, 'debug', 'Niveau >> '.$nomNiveau.' ('.$niveauRestriction.')');
+          log::add(__CLASS__, 'debug', strip_tags(str_replace('<br/>', ' | ', $editorial)));
+
+          $zoneValues[$typeZone] = array(
+            'nom' => $nomZone,
+            'niveau' => $niveauRestriction,
+            'label' => $nomNiveau,
+            'editorial' => $editorial,
+          );
+        }
+
+        if ($typeRestriction == 'sup' || $typeRestriction == 'all') {
+          $this->checkAndUpdateCmd('nom_zone_sup', $zoneValues['SUP']['nom']);
+          $this->checkAndUpdateCmd('niveau_restriction_sup', $zoneValues['SUP']['niveau']);
+          $this->checkAndUpdateCmd('nom_restriction_sup', $zoneValues['SUP']['label']);
+          $this->checkAndUpdateCmd('editorial_zone_sup', $zoneValues['SUP']['editorial']);
+        }
+        if ($typeRestriction == 'sou' || $typeRestriction == 'all') {
+          $this->checkAndUpdateCmd('nom_zone_sou', $zoneValues['SOU']['nom']);
+          $this->checkAndUpdateCmd('niveau_restriction_sou', $zoneValues['SOU']['niveau']);
+          $this->checkAndUpdateCmd('nom_restriction_sou', $zoneValues['SOU']['label']);
+          $this->checkAndUpdateCmd('editorial_zone_sou', $zoneValues['SOU']['editorial']);
+        }
+
+        if ($typeRestriction == 'sup') {
+          $this->checkAndUpdateCmd('nom_zone_sou', '');
+          $this->checkAndUpdateCmd('niveau_restriction_sou', 0);
+          $this->checkAndUpdateCmd('nom_restriction_sou', '');
+          $this->checkAndUpdateCmd('editorial_zone_sou', '');
+        }
+        if ($typeRestriction == 'sou') {
+          $this->checkAndUpdateCmd('nom_zone_sup', '');
+          $this->checkAndUpdateCmd('niveau_restriction_sup', 0);
+          $this->checkAndUpdateCmd('nom_restriction_sup', '');
+          $this->checkAndUpdateCmd('editorial_zone_sup', '');
         }
       }
     }

--- a/core/class/propluvia.class.php
+++ b/core/class/propluvia.class.php
@@ -189,6 +189,134 @@ class propluvia extends eqLogic {
     }
   }
 
+  private function getEnabledUsageKeys() {
+    $raw = $this->getConfiguration('usageFilterIds', '');
+    if (is_array($raw)) {
+      $keys = array();
+      foreach ($raw as $key => $value) {
+        if (is_int($key)) {
+          $stringValue = trim((string) $value);
+          if ($stringValue !== '') {
+            $keys[] = $stringValue;
+          }
+          continue;
+        }
+        if ($value === true || $value === 1 || $value === '1' || $value === 'on') {
+          $keys[] = (string) $key;
+        }
+      }
+      return array_values(array_unique($keys));
+    }
+    if (is_string($raw) && $raw !== '') {
+      $parts = explode(',', $raw);
+      $keys = array();
+      foreach ($parts as $part) {
+        $trimmed = trim($part);
+        if ($trimmed !== '') {
+          $keys[] = $trimmed;
+        }
+      }
+      return array_values(array_unique($keys));
+    }
+    return array();
+  }
+
+  private function buildUsageKey($usage) {
+    if (!is_array($usage)) {
+      return '';
+    }
+    if (isset($usage['id']) && $usage['id'] !== '' && $usage['id'] !== null) {
+      return (string) $usage['id'];
+    }
+    if (!empty($usage['nom'])) {
+      $slug = $this->slugifyUsageLabel($usage['nom']);
+      if ($slug !== '') {
+        return 'nom_'.$slug;
+      }
+    }
+    if (!empty($usage['thematique'])) {
+      $slug = $this->slugifyUsageLabel($usage['thematique']);
+      if ($slug !== '') {
+        return 'thematique_'.$slug;
+      }
+    }
+    return '';
+  }
+
+  private function slugifyUsageLabel($label) {
+    $label = trim((string) $label);
+    if ($label === '') {
+      return '';
+    }
+    $normalized = @iconv('UTF-8', 'ASCII//TRANSLIT//IGNORE', $label);
+    if ($normalized !== false && $normalized !== null) {
+      $label = $normalized;
+    }
+    $labelLower = strtolower($label);
+    $labelSlug = preg_replace('/[^a-z0-9]+/', '_', $labelLower);
+    if (!is_string($labelSlug)) {
+      $labelSlug = '';
+    }
+    $labelSlug = trim($labelSlug, '_');
+    if ($labelSlug !== '') {
+      return $labelSlug;
+    }
+    $fallback = strtolower(preg_replace('/\s+/', '_', trim((string) $label)));
+    return trim($fallback, '_');
+  }
+
+  public function getUsageOptionsForConfig() {
+    $usageMap = array();
+    $usageCommands = array('usages_zone_sup', 'usages_zone_sou', 'usages_zone_aep');
+    foreach ($usageCommands as $logicalId) {
+      $cmd = $this->getCmd('info', $logicalId);
+      if (!is_object($cmd)) {
+        continue;
+      }
+      try {
+        $rawValue = $cmd->execCmd();
+      } catch (Exception $e) {
+        continue;
+      }
+      if (!is_string($rawValue) || $rawValue === '') {
+        continue;
+      }
+      $decoded = json_decode($rawValue, true);
+      if (!is_array($decoded)) {
+        continue;
+      }
+      foreach ($decoded as $usage) {
+        if (!is_array($usage)) {
+          continue;
+        }
+        $key = $this->buildUsageKey($usage);
+        if ($key === '') {
+          continue;
+        }
+        if (!isset($usageMap[$key])) {
+          $usageMap[$key] = array(
+            'key' => $key,
+            'id' => isset($usage['id']) ? $usage['id'] : '',
+            'nom' => isset($usage['nom']) ? $usage['nom'] : '',
+            'thematique' => isset($usage['thematique']) ? $usage['thematique'] : '',
+          );
+        }
+      }
+    }
+    if (empty($usageMap)) {
+      return array();
+    }
+    uasort($usageMap, function ($a, $b) {
+      $themeA = isset($a['thematique']) ? strtolower($a['thematique']) : '';
+      $themeB = isset($b['thematique']) ? strtolower($b['thematique']) : '';
+      if ($themeA === $themeB) {
+        return strcmp(isset($a['nom']) ? strtolower($a['nom']) : '', isset($b['nom']) ? strtolower($b['nom']) : '');
+      }
+      return strcmp($themeA, $themeB);
+    });
+    return array_values($usageMap);
+  }
+
   private function getCommonCommandDefinitions() {
     return array(
       'departement' => array(
@@ -663,11 +791,19 @@ class propluvia extends eqLogic {
           'aucune' => array('label' => __('Aucune restriction', __FILE__), 'value' => 0),
         );
 
-        $buildEditorial = function ($usages) use ($typeInfo) {
+        $enabledUsageKeys = $this->getEnabledUsageKeys();
+        $self = $this;
+        $buildEditorial = function ($usages) use ($typeInfo, $enabledUsageKeys, $self) {
           $messages = array();
           foreach ($usages as $usage) {
             if (!is_array($usage)) {
               continue;
+            }
+            $usageKey = $self->buildUsageKey($usage);
+            if (!empty($enabledUsageKeys)) {
+              if ($usageKey === '' || !in_array($usageKey, $enabledUsageKeys, true)) {
+                continue;
+              }
             }
             $shouldAdd = false;
             switch ($typeInfo) {

--- a/core/class/propluvia.class.php
+++ b/core/class/propluvia.class.php
@@ -437,28 +437,34 @@ class propluvia extends eqLogic {
         'order' => 4,
         'default' => __('Non communiqué', __FILE__)
       ),
+      'numero_arrete_cadre' => array(
+        'name' => __('Numéro arrêté cadre', __FILE__),
+        'subType' => 'string',
+        'order' => 5,
+        'default' => __('Non communiqué', __FILE__)
+      ),
       'date_debut' => array(
         'name' => __('Date début arrêté', __FILE__),
         'subType' => 'string',
-        'order' => 5,
+        'order' => 6,
         'default' => ''
       ),
       'date_fin' => array(
         'name' => __('Date fin arrêté', __FILE__),
         'subType' => 'string',
-        'order' => 6,
+        'order' => 7,
         'default' => ''
       ),
       'urlPdf' => array(
         'name' => __('Url arrêté en pdf', __FILE__),
         'subType' => 'string',
-        'order' => 7,
+        'order' => 8,
         'default' => ''
       ),
       'urlPdfCadre' => array(
         'name' => __('Url arrêté cadre', __FILE__),
         'subType' => 'string',
-        'order' => 8,
+        'order' => 9,
         'default' => ''
       ),
     );
@@ -874,6 +880,7 @@ class propluvia extends eqLogic {
 
         $this->updateCommandIfExists('departement', substr($codeInseeCommune, 0, 2));
         $this->updateCommandIfExists('numero_arrete', 'Aucun arrêté trouvé à la date du '.$dateFormat);
+        $this->updateCommandIfExists('numero_arrete_cadre', 'Aucun arrêté trouvé à la date du '.$dateFormat);
         $this->updateCommandIfExists('date_debut', '');
         $this->updateCommandIfExists('date_fin', '');
         $this->updateCommandIfExists('commune', $nomCommune);
@@ -923,7 +930,10 @@ class propluvia extends eqLogic {
             if ($nomUsage === '' && $description === '') {
               continue;
             }
-            $description = str_replace(array("\r\n", "\n", "\r"), '<br/>', $description);
+            if ($description !== '') {
+              $description = str_replace(array("\r\n", "\n", "\r"), ' ', $description);
+              $description = preg_replace('/\s+/u', ' ', $description);
+            }
             if ($nomUsage !== '' && $description !== '') {
               $messages[] = '<b>'.$nomUsage.'</b> : '.$description;
             } else {
@@ -963,6 +973,7 @@ class propluvia extends eqLogic {
         $dateFinValiditeArrete = '';
         $defaultNumeroArrete = __('Non communiqué', __FILE__);
         $numeroArrete = $defaultNumeroArrete;
+        $numeroArreteCadre = $defaultNumeroArrete;
         $urlPdf = '';
         $urlPdfCadre = '';
 
@@ -991,6 +1002,16 @@ class propluvia extends eqLogic {
             }
             if ($urlPdfCadre === '' && !empty($arrete['cheminFichierArreteCadre'])) {
               $urlPdfCadre = $arrete['cheminFichierArreteCadre'];
+            }
+            if ($numeroArreteCadre === $defaultNumeroArrete) {
+              if (!empty($arrete['idArreteCadre'])) {
+                $numeroArreteCadre = $arrete['idArreteCadre'];
+              } elseif (!empty($arrete['cheminFichierArreteCadre'])) {
+                $path = parse_url($arrete['cheminFichierArreteCadre'], PHP_URL_PATH);
+                if (is_string($path) && preg_match('#/(\d+)/[^/]+$#', $path, $matches)) {
+                  $numeroArreteCadre = $matches[1];
+                }
+              }
             }
           }
 
@@ -1048,6 +1069,7 @@ class propluvia extends eqLogic {
 
         log::add(__CLASS__, 'debug', 'Département            : '.$codeInseeDepartement);
         log::add(__CLASS__, 'debug', 'Numéro arrêté          : '.$numeroArrete);
+        log::add(__CLASS__, 'debug', 'Numéro arrêté cadre    : '.$numeroArreteCadre);
         log::add(__CLASS__, 'debug', 'Début validité arrêté  : '.$dateDebutValiditeArrete);
         log::add(__CLASS__, 'debug', 'Fin validité arrêté    : '.$dateFinValiditeArrete);
         log::add(__CLASS__, 'debug', 'Commune                : '.$nomCommune);
@@ -1056,6 +1078,7 @@ class propluvia extends eqLogic {
 
         $this->updateCommandIfExists('departement', $codeInseeDepartement);
         $this->updateCommandIfExists('numero_arrete', $numeroArrete);
+        $this->updateCommandIfExists('numero_arrete_cadre', $numeroArreteCadre);
         $this->updateCommandIfExists('date_debut', $dateDebutValiditeArrete);
         $this->updateCommandIfExists('date_fin', $dateFinValiditeArrete);
         $this->updateCommandIfExists('commune', $nomCommune);

--- a/core/template/css/propluvia.dashboard.css
+++ b/core/template/css/propluvia.dashboard.css
@@ -41,10 +41,9 @@
         .restriction-scale {
                 margin: 0 auto;
         }
-        .tableau .mesures-label,
-        .tableau .mesures-content,
         .tableau .mesures-row td {
-                background-color: transparent !important;
+                background-color: rgba(201, 235, 248, 0.9) !important;
+                color: #000000 !important;
         }
         .tableau .mesures-label {
                 font-weight: bold;
@@ -52,4 +51,5 @@
         .tableau .mesures-content {
                 text-align: left;
                 white-space: normal;
+                background-color: transparent !important;
         }

--- a/core/template/css/propluvia.dashboard.css
+++ b/core/template/css/propluvia.dashboard.css
@@ -3,15 +3,21 @@
 	src: url("fonts/Barcelona.otf") format("opentype");
 	}
 
-	.tableau{
-      		background-color: #C9EBF8 !important;
-      		border: 5px solid #FFFFFF;
-      		border-radius: 20px !important;
-  		border-spacing:5px;
-      		border-collapse: separate;
-      		color: #000000 !important;
-      		columns:2;
-	}
+        .tableau{
+                background-color: #C9EBF8 !important;
+                border: 5px solid #FFFFFF;
+                border-radius: 20px !important;
+                border-spacing:5px;
+                border-collapse: separate;
+                color: #000000 !important;
+                columns:2;
+        }
+
+        .tableau tr,
+        .tableau th,
+        .tableau td {
+                background-color: #C9EBF8 !important;
+        }
 
   	.tableaux{
   		display:inline-block;
@@ -23,10 +29,9 @@
 	}
 	.demo th {
 	}
-	.tableau td {
-		padding:2px;
-     		background-color: #C9EBF8 !important;
-    	}
+        .tableau td {
+                padding:2px;
+        }
 	.fa-mixer{
    		color: black;
 	}
@@ -42,7 +47,7 @@
                 margin: 0 auto;
         }
         .tableau .mesures-row td {
-                background-color: rgba(201, 235, 248, 0.9) !important;
+                background-color: #C9EBF8 !important;
                 color: #000000 !important;
         }
         .tableau .mesures-label {
@@ -51,5 +56,5 @@
         .tableau .mesures-content {
                 text-align: left;
                 white-space: normal;
-                background-color: transparent !important;
+                background-color: #C9EBF8 !important;
         }

--- a/core/template/css/propluvia.dashboard.css
+++ b/core/template/css/propluvia.dashboard.css
@@ -31,10 +31,25 @@
    		color: black;
 	}
         .lien-arrete {
-        	color: blue !important;
-        	text-decoration: underline !important;
-    	}    
-	.lien-arrete:hover {
-        	color: red !important;
-        	text-decoration: underline !important;
-    	}
+                color: blue !important;
+                text-decoration: underline !important;
+        }
+        .lien-arrete:hover {
+                color: red !important;
+                text-decoration: underline !important;
+        }
+        .restriction-scale {
+                margin: 0 auto;
+        }
+        .tableau .mesures-label,
+        .tableau .mesures-content,
+        .tableau .mesures-row td {
+                background-color: transparent !important;
+        }
+        .tableau .mesures-label {
+                font-weight: bold;
+        }
+        .tableau .mesures-content {
+                text-align: left;
+                white-space: normal;
+        }

--- a/core/template/dashboard/propluvia_aep.template.html
+++ b/core/template/dashboard/propluvia_aep.template.html
@@ -21,7 +21,7 @@
         </tr>
         <tr>
         <td><i class='fas fa-pen'></i></td>
-        <td id="arreteCell">
+        <td id="arreteCell#uid#">
             <script>
                 var urlPdf = "#urlPdf#";
                 var urlPdfCadre = "#urlPdfCadre#";
@@ -41,7 +41,13 @@
                         arreteContent += "<br/><a href='" + urlPdfCadre + "' target='_blank' class='lien-arrete'>Arrêté cadre</a>";
                 }
 
-                document.getElementById("arreteCell").innerHTML = arreteContent;
+                (function() {
+                    var cell = document.getElementById("arreteCell#uid#");
+                    if (!cell) {
+                        return;
+                    }
+                    cell.innerHTML = arreteContent;
+                })();
             </script>
         </td>
         </tr>

--- a/core/template/dashboard/propluvia_aep.template.html
+++ b/core/template/dashboard/propluvia_aep.template.html
@@ -6,21 +6,21 @@
     </span>
     <span class="cmd refresh pull-right cursor" data-cmd_id="#refresh_id#">
       <i class="fas fa-sync"></i>
-    </span>   
-	<span class="reportModeVisible">#name_display# <span class="object_name">#object_name#</span></span>
+    </span>
+        <span class="reportModeVisible">#name_display# <span class="object_name">#object_name#</span></span>
     <a href="#eqLink#" class="reportModeHidden">#name_display# <span class="object_name">#object_name#</span></a>
   </center>
   <div class="#isVerticalAlign#">
     <center>
 
 <table class="tableau">
-	<tbody>
-	<tr>
-		<td><i class='fas fa-map-pin'></i></td>
-      	<td>Commune : #commune# (#departement#)</td>
-	</tr>
-	<tr>
-      	<td><i class='fas fa-pen'></i></td>
+        <tbody>
+        <tr>
+                <td><i class='fas fa-map-pin'></i></td>
+        <td>Commune : #commune# (#departement#)</td>
+        </tr>
+        <tr>
+        <td><i class='fas fa-pen'></i></td>
         <td id="arreteCell">
             <script>
                 var urlPdf = "#urlPdf#";
@@ -44,62 +44,62 @@
                 document.getElementById("arreteCell").innerHTML = arreteContent;
             </script>
         </td>
-	</tr>
+        </tr>
     <tr>
-      	<td><i class='fas fa-angle-right'></i></td>
-		<td>Date de début : #date_debut#</td>
-	</tr>
+        <td><i class='fas fa-angle-right'></i></td>
+                <td>Date de début : #date_debut#</td>
+        </tr>
     <tr>
-      	<td><i class='fas fa-angle-right'></i></td>
-		<td>Date de fin : #date_fin#</td>
-	</tr>
-	</tbody>
+        <td><i class='fas fa-angle-right'></i></td>
+                <td>Date de fin : #date_fin#</td>
+        </tr>
+        </tbody>
 </table>
-      
-<div class="tableaux">      
-<table class="tableau">
-	<tbody>
+
+<div class="tableaux">
+  <table class="tableau">
+        <tbody>
     <tr>
-      <td colspan="2" style="width: 300px; font-weight: bold;"><center>Nappes (SOU)</center></td>
-	</tr>
-	<tr>
-		<td style="width: 10px;"><i class='fas fa-map-pin'></i></td>
-      	<td>Nom : #nom_zone_sou#</td>
-	</tr>
-	<tr>
-      	<td><i class='fas fa-pen'></i></td>
-		<td>Restriction : #nom_restriction_sou#</td>
-	</tr>
+      <td colspan="2" style="width: 300px; font-weight: bold;"><center>Eau du robinet (AEP)</center></td>
+        </tr>
+        <tr>
+                <td style="width: 10px;"><i class='fas fa-map-pin'></i></td>
+        <td>Nom : #nom_zone_aep#</td>
+        </tr>
+        <tr>
+        <td><i class='fas fa-pen'></i></td>
+                <td>Restriction : #nom_restriction_aep#</td>
+        </tr>
     <tr>
-      	<td colspan="2">
-          <table border="0">
-          <tbody> 
+        <td colspan="2">
+        <table border="0">
+          <tbody>
             <tr style="border: 1px black;">
-              <td style="width: 60px; height: 20px; background-color: #ffffff !important;">#nom_restriction_sou_N1#
+              <td style="width: 60px; height: 20px; background-color: #ffffff !important;">#nom_restriction_aep_N1#
               </td>
-              <td style="width: 60px; height: 20px; background-color: #7f7f7f !important;">#nom_restriction_sou_N2#
+              <td style="width: 60px; height: 20px; background-color: #7f7f7f !important;">#nom_restriction_aep_N2#
               </td>
-              <td style="width: 60px; height: 20px; background-color: #fae805 !important;">#nom_restriction_sou_N3#
+              <td style="width: 60px; height: 20px; background-color: #fae805 !important;">#nom_restriction_aep_N3#
               </td>
-              <td style="width: 60px; height: 20px; background-color: #ff9900 !important;">#nom_restriction_sou_N4#
+              <td style="width: 60px; height: 20px; background-color: #ff9900 !important;">#nom_restriction_aep_N4#
               </td>
-              <td style="width: 60px; height: 20px; background-color: #ff0000 !important;">#nom_restriction_sou_N5#
+              <td style="width: 60px; height: 20px; background-color: #ff0000 !important;">#nom_restriction_aep_N5#
               </td>
             </tr>
           </tbody>
         </table>
       </td>
-	</tr>
+        </tr>
     <tr>
-      	<td><i class='fas fa-angle-right'></i></td>
-		<td>Mesures : #editorial_zone_sou#</td>
-	</tr>
-	</tbody>
+        <td><i class='fas fa-angle-right'></i></td>
+                <td>Mesures : #editorial_zone_aep#</td>
+        </tr>
+        </tbody>
 </table>
-      </div>
-  
-  <div style="font-size: 10px; font-style: italic; text-align:left;margin-left: 5px">
-	#lastActuPropluvia#
+</div>
+
+      <div style="font-size: 10px; font-style: italic; text-align:left;margin-left: 5px">
+        #lastActuPropluvia#
   </div>
 
     </center>
@@ -110,7 +110,7 @@
 //    eqLogic.find('.propluviaCdc').css('font-size', (eqlogic_height * 0.05) + 'px')
 //    eqLogic.find('.propluviaValue, .propluviaTitle').css('font-size', (eqlogic_height * 0.06) + 'px')
 //    eqLogic.find('.propluviaUnite, .propluviaTitleIcon').css('font-size', (eqlogic_height * 0.04) + 'px')
-    
+
     if ('#refresh_id#' != '') {
       $('.eqLogic[data-eqLogic_uid=#uid#] .refresh').on('click', function () {
         jeedom.cmd.execute({id: '#refresh_id#'})

--- a/core/template/dashboard/propluvia_aep.template.html
+++ b/core/template/dashboard/propluvia_aep.template.html
@@ -22,33 +22,47 @@
         <tr>
         <td><i class='fas fa-pen'></i></td>
         <td id="arreteCell#uid#">
-            <script>
-                var urlPdf = "#urlPdf#";
-                var urlPdfCadre = "#urlPdfCadre#";
-                var numeroArrete = "#numero_arrete#";
-                var numeroTexte = numeroArrete ? numeroArrete.trim() : '';
-                var numeroConnu = numeroTexte !== '' && numeroTexte.toLowerCase() !== 'non communiqué';
-                var arreteContent = '';
+                <script>
+                        (function() {
+                                var urlPdf = "#urlPdf#";
+                                var urlPdfCadre = "#urlPdfCadre#";
+                                var numeroArrete = "#numero_arrete#";
+                                var numeroArreteCadre = "#numero_arrete_cadre#";
 
-                if (urlPdf !== '') {
-                        var numeroLabel = numeroConnu ? "n° " + numeroTexte : "Consulter le PDF";
-                        arreteContent = "Arrêté : <a href='" + urlPdf + "' target='_blank' class='lien-arrete'>" + numeroLabel + "</a>";
-                } else {
-                    arreteContent = "Arrêté : " + numeroArrete;
-                }
+                                var sanitize = function(value) {
+                                        return (value || '').toString().trim();
+                                };
 
-                if (urlPdfCadre !== '') {
-                        arreteContent += "<br/><a href='" + urlPdfCadre + "' target='_blank' class='lien-arrete'>Arrêté cadre</a>";
-                }
+                                var isKnown = function(value) {
+                                        if (value === '') {
+                                                return false;
+                                        }
+                                        var lower = value.toLowerCase();
+                                        return lower !== 'non communiqué' && lower.indexOf('aucun') === -1;
+                                };
 
-                (function() {
-                    var cell = document.getElementById("arreteCell#uid#");
-                    if (!cell) {
-                        return;
-                    }
-                    cell.innerHTML = arreteContent;
-                })();
-            </script>
+                                var buildLine = function(label, url, numero, rawValue) {
+                                        var cleanNumero = sanitize(numero);
+                                        var cleanRaw = sanitize(rawValue);
+                                        var known = isKnown(cleanNumero);
+                                        var fallback = known ? 'N° ' + cleanNumero : (cleanRaw !== '' ? cleanRaw : 'Non communiqué');
+                                        if (url !== '') {
+                                                var linkLabel = known ? 'N° ' + cleanNumero : (isKnown(cleanRaw) ? cleanRaw : 'Consulter le PDF');
+                                                return label + ' : <a href="' + url + '" target="_blank" class="lien-arrete">' + linkLabel + '</a>';
+                                        }
+                                        return label + ' : ' + fallback;
+                                };
+
+                                var restrictionLine = buildLine('Arrêté de restriction', urlPdf, numeroArrete, numeroArrete);
+                                var cadreLine = buildLine('Arrêté cadre', urlPdfCadre, numeroArreteCadre, numeroArreteCadre);
+
+                                var cell = document.getElementById('arreteCell#uid#');
+                                if (!cell) {
+                                        return;
+                                }
+                                cell.innerHTML = restrictionLine + '<br/>' + cadreLine;
+                        })();
+                </script>
         </td>
         </tr>
     <tr>
@@ -78,7 +92,7 @@
         </tr>
     <tr>
         <td colspan="2">
-        <table border="0">
+        <table border="0" class="restriction-scale">
           <tbody>
             <tr style="border: 1px black;">
               <td style="width: 60px; height: 20px; background-color: #ffffff !important;">#nom_restriction_aep_N1#
@@ -98,7 +112,11 @@
         </tr>
     <tr>
         <td><i class='fas fa-angle-right'></i></td>
-                <td>Mesures : #editorial_zone_aep#</td>
+                <td class="mesures-label">&gt; Mesures :</td>
+        </tr>
+    <tr class="mesures-row">
+        <td></td>
+        <td class="mesures-content">#editorial_zone_aep#</td>
         </tr>
         </tbody>
 </table>

--- a/core/template/dashboard/propluvia_all.template.html
+++ b/core/template/dashboard/propluvia_all.template.html
@@ -58,22 +58,64 @@
       
 <div class="tableaux">
   <table class="tableau">
-	<tbody>
+        <tbody>
     <tr>
-      <td colspan="2" style="width: 300px; font-weight: bold;"><center>Eaux superficielles</center></td>
-	</tr>
-	<tr>
-		<td style="width: 10px;"><i class='fas fa-map-pin'></i></td>
-      	<td>Nom : #nom_zone_sup#</td>
-	</tr>
-	<tr>
-      	<td><i class='fas fa-pen'></i></td>
-		<td>Restriction : #nom_restriction_sup#</td>
-	</tr>
+      <td colspan="2" style="width: 300px; font-weight: bold;"><center>Eau du robinet (AEP)</center></td>
+        </tr>
+        <tr>
+                <td style="width: 10px;"><i class='fas fa-map-pin'></i></td>
+        <td>Nom : #nom_zone_aep#</td>
+        </tr>
+        <tr>
+        <td><i class='fas fa-pen'></i></td>
+                <td>Restriction : #nom_restriction_aep#</td>
+        </tr>
     <tr>
-      	<td colspan="2">
+        <td colspan="2">
         <table border="0">
-          <tbody> 
+          <tbody>
+            <tr style="border: 1px black;">
+              <td style="width: 60px; height: 20px; background-color: #ffffff !important;">#nom_restriction_aep_N1#
+              </td>
+              <td style="width: 60px; height: 20px; background-color: #7f7f7f !important;">#nom_restriction_aep_N2#
+              </td>
+              <td style="width: 60px; height: 20px; background-color: #fae805 !important;">#nom_restriction_aep_N3#
+              </td>
+              <td style="width: 60px; height: 20px; background-color: #ff9900 !important;">#nom_restriction_aep_N4#
+              </td>
+              <td style="width: 60px; height: 20px; background-color: #ff0000 !important;">#nom_restriction_aep_N5#
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </td>
+        </tr>
+    <tr>
+        <td><i class='fas fa-angle-right'></i></td>
+                <td>Mesures : #editorial_zone_aep#</td>
+        </tr>
+        </tbody>
+</table>
+</div>
+
+<div class="tableaux">
+  <table class="tableau">
+        <tbody>
+    <tr>
+      <td colspan="2" style="width: 300px; font-weight: bold;"><center>Cours d'eau et rivières (SUP)</center></td>
+        </tr>
+        <tr>
+                <td style="width: 10px;"><i class='fas fa-map-pin'></i></td>
+        <td>Nom : #nom_zone_sup#</td>
+        </tr>
+        <tr>
+        <td><i class='fas fa-pen'></i></td>
+                <td>Restriction : #nom_restriction_sup#</td>
+        </tr>
+    <tr>
+        <td colspan="2">
+        <table border="0">
+          <tbody>
             <tr style="border: 1px black;">
               <td style="width: 60px; height: 20px; background-color: #ffffff !important;">#nom_restriction_sup_N1#
               </td>
@@ -89,33 +131,33 @@
           </tbody>
         </table>
       </td>
-	</tr>
+        </tr>
     <tr>
-      	<td><i class='fas fa-angle-right'></i></td>
-		<td>Mesures : #editorial_zone_sup#</td>
-	</tr>
-	</tbody>
+        <td><i class='fas fa-angle-right'></i></td>
+                <td>Mesures : #editorial_zone_sup#</td>
+        </tr>
+        </tbody>
 </table>
 </div>
-      
-<div class="tableaux">      
+
+<div class="tableaux">
 <table class="tableau">
-	<tbody>
+        <tbody>
     <tr>
-      <td colspan="2" style="width: 300px; font-weight: bold;"><center>Eaux souterraines</center></td>
-	</tr>
-	<tr>
-		<td style="width: 10px;"><i class='fas fa-map-pin'></i></td>
-      	<td>Nom : #nom_zone_sou#</td>
-	</tr>
-	<tr>
-      	<td><i class='fas fa-pen'></i></td>
-		<td>Restriction : #nom_restriction_sou#</td>
-	</tr>
+      <td colspan="2" style="width: 300px; font-weight: bold;"><center>Nappes (SOU)</center></td>
+        </tr>
+        <tr>
+                <td style="width: 10px;"><i class='fas fa-map-pin'></i></td>
+        <td>Nom : #nom_zone_sou#</td>
+        </tr>
+        <tr>
+        <td><i class='fas fa-pen'></i></td>
+                <td>Restriction : #nom_restriction_sou#</td>
+        </tr>
     <tr>
-      	<td colspan="2">
+        <td colspan="2">
         <table border="0">
-          <tbody> 
+          <tbody>
             <tr style="border: 1px black;">
               <td style="width: 60px; height: 20px; background-color: #ffffff !important;">#nom_restriction_sou_N1#
               </td>
@@ -131,12 +173,12 @@
           </tbody>
         </table>
       </td>
-	</tr>
+        </tr>
     <tr>
-      	<td><i class='fas fa-angle-right'></i></td>
-		<td>Mesures : #editorial_zone_sou#</td>
-	</tr>
-	</tbody>
+        <td><i class='fas fa-angle-right'></i></td>
+                <td>Mesures : #editorial_zone_sou#</td>
+        </tr>
+        </tbody>
 </table>
 </div>
   

--- a/core/template/dashboard/propluvia_all.template.html
+++ b/core/template/dashboard/propluvia_all.template.html
@@ -21,7 +21,7 @@
 	</tr>
 	<tr>
 		<td><i class='fas fa-pen'></i></td>
-                <td id="arreteCell">
+                <td id="arreteCell#uid#">
                         <script>
                                 var urlPdf = "#urlPdf#";
                                 var urlPdfCadre = "#urlPdfCadre#";
@@ -41,8 +41,14 @@
                                         arreteContent += "<br/><a href='" + urlPdfCadre + "' target='_blank' class='lien-arrete'>Arrêté cadre</a>";
                                 }
 
-                                document.getElementById("arreteCell").innerHTML = arreteContent;
-                        </script>
+                                (function() {
+                                    var cell = document.getElementById("arreteCell#uid#");
+                                    if (!cell) {
+                                        return;
+                                    }
+                                    cell.innerHTML = arreteContent;
+                                })();
+                </script>
                 </td>
 	</tr>
     <tr>

--- a/core/template/dashboard/propluvia_all.template.html
+++ b/core/template/dashboard/propluvia_all.template.html
@@ -21,18 +21,29 @@
 	</tr>
 	<tr>
 		<td><i class='fas fa-pen'></i></td>
-		<td id="arreteCell">
-			<script>
-				var urlPdf = "#urlPdf#";
-				var numeroArrete = "#numero_arrete#";
+                <td id="arreteCell">
+                        <script>
+                                var urlPdf = "#urlPdf#";
+                                var urlPdfCadre = "#urlPdfCadre#";
+                                var numeroArrete = "#numero_arrete#";
+                                var numeroTexte = numeroArrete ? numeroArrete.trim() : '';
+                                var numeroConnu = numeroTexte !== '' && numeroTexte.toLowerCase() !== 'non communiqué';
+                                var arreteContent = '';
 
-				if (urlPdf !== '') {
-					document.getElementById("arreteCell").innerHTML = "Arrêté : n° <a href='" + urlPdf + "' target='_blank' class='lien-arrete'>" + numeroArrete + "</a>";
-				} else {
-					document.getElementById("arreteCell").innerHTML = "Arrêté : " + numeroArrete;
-				}
-			</script>
-		</td>
+                                if (urlPdf !== '') {
+                                        var numeroLabel = numeroConnu ? "n° " + numeroTexte : "Consulter le PDF";
+                                        arreteContent = "Arrêté : <a href='" + urlPdf + "' target='_blank' class='lien-arrete'>" + numeroLabel + "</a>";
+                                } else {
+                                        arreteContent = "Arrêté : " + numeroArrete;
+                                }
+
+                                if (urlPdfCadre !== '') {
+                                        arreteContent += "<br/><a href='" + urlPdfCadre + "' target='_blank' class='lien-arrete'>Arrêté cadre</a>";
+                                }
+
+                                document.getElementById("arreteCell").innerHTML = arreteContent;
+                        </script>
+                </td>
 	</tr>
     <tr>
       	<td><i class='fas fa-angle-right'></i></td>

--- a/core/template/dashboard/propluvia_all.template.html
+++ b/core/template/dashboard/propluvia_all.template.html
@@ -19,38 +19,52 @@
 		<td><i class='fas fa-map-pin'></i></td>
       	<td>Commune : #commune# (#departement#)</td>
 	</tr>
-	<tr>
-		<td><i class='fas fa-pen'></i></td>
+        <tr>
+                <td><i class='fas fa-pen'></i></td>
                 <td id="arreteCell#uid#">
                         <script>
-                                var urlPdf = "#urlPdf#";
-                                var urlPdfCadre = "#urlPdfCadre#";
-                                var numeroArrete = "#numero_arrete#";
-                                var numeroTexte = numeroArrete ? numeroArrete.trim() : '';
-                                var numeroConnu = numeroTexte !== '' && numeroTexte.toLowerCase() !== 'non communiqué';
-                                var arreteContent = '';
-
-                                if (urlPdf !== '') {
-                                        var numeroLabel = numeroConnu ? "n° " + numeroTexte : "Consulter le PDF";
-                                        arreteContent = "Arrêté : <a href='" + urlPdf + "' target='_blank' class='lien-arrete'>" + numeroLabel + "</a>";
-                                } else {
-                                        arreteContent = "Arrêté : " + numeroArrete;
-                                }
-
-                                if (urlPdfCadre !== '') {
-                                        arreteContent += "<br/><a href='" + urlPdfCadre + "' target='_blank' class='lien-arrete'>Arrêté cadre</a>";
-                                }
-
                                 (function() {
-                                    var cell = document.getElementById("arreteCell#uid#");
-                                    if (!cell) {
-                                        return;
-                                    }
-                                    cell.innerHTML = arreteContent;
+                                        var urlPdf = "#urlPdf#";
+                                        var urlPdfCadre = "#urlPdfCadre#";
+                                        var numeroArrete = "#numero_arrete#";
+                                        var numeroArreteCadre = "#numero_arrete_cadre#";
+
+                                        var sanitize = function(value) {
+                                                return (value || '').toString().trim();
+                                        };
+
+                                        var isKnown = function(value) {
+                                                if (value === '') {
+                                                        return false;
+                                                }
+                                                var lower = value.toLowerCase();
+                                                return lower !== 'non communiqué' && lower.indexOf('aucun') === -1;
+                                        };
+
+                                        var buildLine = function(label, url, numero, rawValue) {
+                                                var cleanNumero = sanitize(numero);
+                                                var cleanRaw = sanitize(rawValue);
+                                                var known = isKnown(cleanNumero);
+                                                var fallback = known ? 'N° ' + cleanNumero : (cleanRaw !== '' ? cleanRaw : 'Non communiqué');
+                                                if (url !== '') {
+                                                        var linkLabel = known ? 'N° ' + cleanNumero : (isKnown(cleanRaw) ? cleanRaw : 'Consulter le PDF');
+                                                        return label + ' : <a href="' + url + '" target="_blank" class="lien-arrete">' + linkLabel + '</a>';
+                                                }
+                                                return label + ' : ' + fallback;
+                                        };
+
+                                        var restrictionLine = buildLine('Arrêté de restriction', urlPdf, numeroArrete, numeroArrete);
+                                        var cadreLine = buildLine('Arrêté cadre', urlPdfCadre, numeroArreteCadre, numeroArreteCadre);
+
+                                        var cell = document.getElementById('arreteCell#uid#');
+                                        if (!cell) {
+                                                return;
+                                        }
+                                        cell.innerHTML = restrictionLine + '<br/>' + cadreLine;
                                 })();
                 </script>
                 </td>
-	</tr>
+        </tr>
     <tr>
       	<td><i class='fas fa-angle-right'></i></td>
 		<td>Date de début : #date_debut#</td>
@@ -78,7 +92,7 @@
         </tr>
     <tr>
         <td colspan="2">
-        <table border="0">
+        <table border="0" class="restriction-scale">
           <tbody>
             <tr style="border: 1px black;">
               <td style="width: 60px; height: 20px; background-color: #ffffff !important;">#nom_restriction_aep_N1#
@@ -98,7 +112,11 @@
         </tr>
     <tr>
         <td><i class='fas fa-angle-right'></i></td>
-                <td>Mesures : #editorial_zone_aep#</td>
+                <td class="mesures-label">&gt; Mesures :</td>
+        </tr>
+    <tr class="mesures-row">
+        <td></td>
+        <td class="mesures-content">#editorial_zone_aep#</td>
         </tr>
         </tbody>
 </table>
@@ -120,7 +138,7 @@
         </tr>
     <tr>
         <td colspan="2">
-        <table border="0">
+        <table border="0" class="restriction-scale">
           <tbody>
             <tr style="border: 1px black;">
               <td style="width: 60px; height: 20px; background-color: #ffffff !important;">#nom_restriction_sup_N1#
@@ -140,7 +158,11 @@
         </tr>
     <tr>
         <td><i class='fas fa-angle-right'></i></td>
-                <td>Mesures : #editorial_zone_sup#</td>
+                <td class="mesures-label">&gt; Mesures :</td>
+        </tr>
+    <tr class="mesures-row">
+        <td></td>
+        <td class="mesures-content">#editorial_zone_sup#</td>
         </tr>
         </tbody>
 </table>
@@ -162,7 +184,7 @@
         </tr>
     <tr>
         <td colspan="2">
-        <table border="0">
+        <table border="0" class="restriction-scale">
           <tbody>
             <tr style="border: 1px black;">
               <td style="width: 60px; height: 20px; background-color: #ffffff !important;">#nom_restriction_sou_N1#
@@ -182,7 +204,11 @@
         </tr>
     <tr>
         <td><i class='fas fa-angle-right'></i></td>
-                <td>Mesures : #editorial_zone_sou#</td>
+                <td class="mesures-label">&gt; Mesures :</td>
+        </tr>
+    <tr class="mesures-row">
+        <td></td>
+        <td class="mesures-content">#editorial_zone_sou#</td>
         </tr>
         </tbody>
 </table>

--- a/core/template/dashboard/propluvia_sou.template.html
+++ b/core/template/dashboard/propluvia_sou.template.html
@@ -22,33 +22,47 @@
 	<tr>
       	<td><i class='fas fa-pen'></i></td>
         <td id="arreteCell#uid#">
-            <script>
-                var urlPdf = "#urlPdf#";
-                var urlPdfCadre = "#urlPdfCadre#";
-                var numeroArrete = "#numero_arrete#";
-                var numeroTexte = numeroArrete ? numeroArrete.trim() : '';
-                var numeroConnu = numeroTexte !== '' && numeroTexte.toLowerCase() !== 'non communiqué';
-                var arreteContent = '';
+                <script>
+                        (function() {
+                                var urlPdf = "#urlPdf#";
+                                var urlPdfCadre = "#urlPdfCadre#";
+                                var numeroArrete = "#numero_arrete#";
+                                var numeroArreteCadre = "#numero_arrete_cadre#";
 
-                if (urlPdf !== '') {
-                        var numeroLabel = numeroConnu ? "n° " + numeroTexte : "Consulter le PDF";
-                        arreteContent = "Arrêté : <a href='" + urlPdf + "' target='_blank' class='lien-arrete'>" + numeroLabel + "</a>";
-                } else {
-                    arreteContent = "Arrêté : " + numeroArrete;
-                }
+                                var sanitize = function(value) {
+                                        return (value || '').toString().trim();
+                                };
 
-                if (urlPdfCadre !== '') {
-                        arreteContent += "<br/><a href='" + urlPdfCadre + "' target='_blank' class='lien-arrete'>Arrêté cadre</a>";
-                }
+                                var isKnown = function(value) {
+                                        if (value === '') {
+                                                return false;
+                                        }
+                                        var lower = value.toLowerCase();
+                                        return lower !== 'non communiqué' && lower.indexOf('aucun') === -1;
+                                };
 
-                (function() {
-                    var cell = document.getElementById("arreteCell#uid#");
-                    if (!cell) {
-                        return;
-                    }
-                    cell.innerHTML = arreteContent;
-                })();
-            </script>
+                                var buildLine = function(label, url, numero, rawValue) {
+                                        var cleanNumero = sanitize(numero);
+                                        var cleanRaw = sanitize(rawValue);
+                                        var known = isKnown(cleanNumero);
+                                        var fallback = known ? 'N° ' + cleanNumero : (cleanRaw !== '' ? cleanRaw : 'Non communiqué');
+                                        if (url !== '') {
+                                                var linkLabel = known ? 'N° ' + cleanNumero : (isKnown(cleanRaw) ? cleanRaw : 'Consulter le PDF');
+                                                return label + ' : <a href="' + url + '" target="_blank" class="lien-arrete">' + linkLabel + '</a>';
+                                        }
+                                        return label + ' : ' + fallback;
+                                };
+
+                                var restrictionLine = buildLine('Arrêté de restriction', urlPdf, numeroArrete, numeroArrete);
+                                var cadreLine = buildLine('Arrêté cadre', urlPdfCadre, numeroArreteCadre, numeroArreteCadre);
+
+                                var cell = document.getElementById('arreteCell#uid#');
+                                if (!cell) {
+                                        return;
+                                }
+                                cell.innerHTML = restrictionLine + '<br/>' + cadreLine;
+                        })();
+                </script>
         </td>
 	</tr>
     <tr>
@@ -78,8 +92,8 @@
 	</tr>
     <tr>
       	<td colspan="2">
-          <table border="0">
-          <tbody> 
+        <table border="0" class="restriction-scale">
+          <tbody>
             <tr style="border: 1px black;">
               <td style="width: 60px; height: 20px; background-color: #ffffff !important;">#nom_restriction_sou_N1#
               </td>
@@ -97,9 +111,13 @@
       </td>
 	</tr>
     <tr>
-      	<td><i class='fas fa-angle-right'></i></td>
-		<td>Mesures : #editorial_zone_sou#</td>
-	</tr>
+        <td><i class='fas fa-angle-right'></i></td>
+                <td class="mesures-label">&gt; Mesures :</td>
+        </tr>
+    <tr class="mesures-row">
+        <td></td>
+        <td class="mesures-content">#editorial_zone_sou#</td>
+        </tr>
 	</tbody>
 </table>
       </div>

--- a/core/template/dashboard/propluvia_sou.template.html
+++ b/core/template/dashboard/propluvia_sou.template.html
@@ -21,7 +21,7 @@
 	</tr>
 	<tr>
       	<td><i class='fas fa-pen'></i></td>
-        <td id="arreteCell">
+        <td id="arreteCell#uid#">
             <script>
                 var urlPdf = "#urlPdf#";
                 var urlPdfCadre = "#urlPdfCadre#";
@@ -41,7 +41,13 @@
                         arreteContent += "<br/><a href='" + urlPdfCadre + "' target='_blank' class='lien-arrete'>Arrêté cadre</a>";
                 }
 
-                document.getElementById("arreteCell").innerHTML = arreteContent;
+                (function() {
+                    var cell = document.getElementById("arreteCell#uid#");
+                    if (!cell) {
+                        return;
+                    }
+                    cell.innerHTML = arreteContent;
+                })();
             </script>
         </td>
 	</tr>

--- a/core/template/dashboard/propluvia_sou.template.html
+++ b/core/template/dashboard/propluvia_sou.template.html
@@ -24,15 +24,26 @@
         <td id="arreteCell">
             <script>
                 var urlPdf = "#urlPdf#";
+                var urlPdfCadre = "#urlPdfCadre#";
                 var numeroArrete = "#numero_arrete#";
+                var numeroTexte = numeroArrete ? numeroArrete.trim() : '';
+                var numeroConnu = numeroTexte !== '' && numeroTexte.toLowerCase() !== 'non communiqué';
+                var arreteContent = '';
 
                 if (urlPdf !== '') {
-            		document.getElementById("arreteCell").innerHTML = "Arrêté : n° <a href='" + urlPdf + "' target='_blank' class='lien-arrete'>" + numeroArrete + "</a>";
+                        var numeroLabel = numeroConnu ? "n° " + numeroTexte : "Consulter le PDF";
+                        arreteContent = "Arrêté : <a href='" + urlPdf + "' target='_blank' class='lien-arrete'>" + numeroLabel + "</a>";
                 } else {
-                    document.getElementById("arreteCell").innerHTML = "Arrêté : " + numeroArrete;
+                    arreteContent = "Arrêté : " + numeroArrete;
                 }
+
+                if (urlPdfCadre !== '') {
+                        arreteContent += "<br/><a href='" + urlPdfCadre + "' target='_blank' class='lien-arrete'>Arrêté cadre</a>";
+                }
+
+                document.getElementById("arreteCell").innerHTML = arreteContent;
             </script>
-        </td>	
+        </td>
 	</tr>
     <tr>
       	<td><i class='fas fa-angle-right'></i></td>

--- a/core/template/dashboard/propluvia_sup.template.html
+++ b/core/template/dashboard/propluvia_sup.template.html
@@ -23,30 +23,44 @@
       	<td><i class='fas fa-pen'></i></td>
         <td id="arreteCell#uid#">
             <script>
-                var urlPdf = "#urlPdf#";
-                var urlPdfCadre = "#urlPdfCadre#";
-                var numeroArrete = "#numero_arrete#";
-                var numeroTexte = numeroArrete ? numeroArrete.trim() : '';
-                var numeroConnu = numeroTexte !== '' && numeroTexte.toLowerCase() !== 'non communiqué';
-                var arreteContent = '';
-
-                if (urlPdf !== '') {
-                        var numeroLabel = numeroConnu ? "n° " + numeroTexte : "Consulter le PDF";
-                        arreteContent = "Arrêté : <a href='" + urlPdf + "' target='_blank' class='lien-arrete'>" + numeroLabel + "</a>";
-                } else {
-                    arreteContent = "Arrêté : " + numeroArrete;
-                }
-
-                if (urlPdfCadre !== '') {
-                        arreteContent += "<br/><a href='" + urlPdfCadre + "' target='_blank' class='lien-arrete'>Arrêté cadre</a>";
-                }
-
                 (function() {
-                    var cell = document.getElementById("arreteCell#uid#");
+                    var urlPdf = "#urlPdf#";
+                    var urlPdfCadre = "#urlPdfCadre#";
+                    var numeroArrete = "#numero_arrete#";
+                    var numeroArreteCadre = "#numero_arrete_cadre#";
+
+                    var sanitize = function(value) {
+                        return (value || '').toString().trim();
+                    };
+
+                    var isKnown = function(value) {
+                        if (value === '') {
+                            return false;
+                        }
+                        var lower = value.toLowerCase();
+                        return lower !== 'non communiqué' && lower.indexOf('aucun') === -1;
+                    };
+
+                    var buildLine = function(label, url, numero, rawValue) {
+                        var cleanNumero = sanitize(numero);
+                        var cleanRaw = sanitize(rawValue);
+                        var known = isKnown(cleanNumero);
+                        var fallback = known ? 'N° ' + cleanNumero : (cleanRaw !== '' ? cleanRaw : 'Non communiqué');
+                        if (url !== '') {
+                            var linkLabel = known ? 'N° ' + cleanNumero : (isKnown(cleanRaw) ? cleanRaw : 'Consulter le PDF');
+                            return label + ' : <a href="' + url + '" target="_blank" class="lien-arrete">' + linkLabel + '</a>';
+                        }
+                        return label + ' : ' + fallback;
+                    };
+
+                    var restrictionLine = buildLine('Arrêté de restriction', urlPdf, numeroArrete, numeroArrete);
+                    var cadreLine = buildLine('Arrêté cadre', urlPdfCadre, numeroArreteCadre, numeroArreteCadre);
+
+                    var cell = document.getElementById('arreteCell#uid#');
                     if (!cell) {
                         return;
                     }
-                    cell.innerHTML = arreteContent;
+                    cell.innerHTML = restrictionLine + '<br/>' + cadreLine;
                 })();
             </script>
         </td>
@@ -78,8 +92,8 @@
 	</tr>
     <tr>
       	<td colspan="2">
-        <table border="0">
-          <tbody> 
+        <table border="0" class="restriction-scale">
+          <tbody>
             <tr style="border: 1px black;">
               <td style="width: 60px; height: 20px; background-color: #ffffff !important;">#nom_restriction_sup_N1#
               </td>
@@ -97,9 +111,13 @@
       </td>
 	</tr>
     <tr>
-      	<td><i class='fas fa-angle-right'></i></td>
-		<td>Mesures : #editorial_zone_sup#</td>
-	</tr>
+        <td><i class='fas fa-angle-right'></i></td>
+                <td class="mesures-label">&gt; Mesures :</td>
+        </tr>
+    <tr class="mesures-row">
+        <td></td>
+        <td class="mesures-content">#editorial_zone_sup#</td>
+        </tr>
 	</tbody>
 </table>
 </div>

--- a/core/template/dashboard/propluvia_sup.template.html
+++ b/core/template/dashboard/propluvia_sup.template.html
@@ -21,7 +21,7 @@
 	</tr>
 	<tr>
       	<td><i class='fas fa-pen'></i></td>
-        <td id="arreteCell">
+        <td id="arreteCell#uid#">
             <script>
                 var urlPdf = "#urlPdf#";
                 var urlPdfCadre = "#urlPdfCadre#";
@@ -41,7 +41,13 @@
                         arreteContent += "<br/><a href='" + urlPdfCadre + "' target='_blank' class='lien-arrete'>Arrêté cadre</a>";
                 }
 
-                document.getElementById("arreteCell").innerHTML = arreteContent;
+                (function() {
+                    var cell = document.getElementById("arreteCell#uid#");
+                    if (!cell) {
+                        return;
+                    }
+                    cell.innerHTML = arreteContent;
+                })();
             </script>
         </td>
 	</tr>

--- a/core/template/dashboard/propluvia_sup.template.html
+++ b/core/template/dashboard/propluvia_sup.template.html
@@ -60,7 +60,7 @@
   <table class="tableau">
 	<tbody>
     <tr>
-      <td colspan="2" style="width: 300px; font-weight: bold;"><center>Eaux superficielles</center></td>
+      <td colspan="2" style="width: 300px; font-weight: bold;"><center>Cours d'eau et rivières (SUP)</center></td>
 	</tr>
 	<tr>
 		<td style="width: 10px;"><i class='fas fa-map-pin'></i></td>

--- a/core/template/dashboard/propluvia_sup.template.html
+++ b/core/template/dashboard/propluvia_sup.template.html
@@ -24,13 +24,24 @@
         <td id="arreteCell">
             <script>
                 var urlPdf = "#urlPdf#";
+                var urlPdfCadre = "#urlPdfCadre#";
                 var numeroArrete = "#numero_arrete#";
+                var numeroTexte = numeroArrete ? numeroArrete.trim() : '';
+                var numeroConnu = numeroTexte !== '' && numeroTexte.toLowerCase() !== 'non communiqué';
+                var arreteContent = '';
 
                 if (urlPdf !== '') {
-            		document.getElementById("arreteCell").innerHTML = "Arrêté : n° <a href='" + urlPdf + "' target='_blank' class='lien-arrete'>" + numeroArrete + "</a>";
+                        var numeroLabel = numeroConnu ? "n° " + numeroTexte : "Consulter le PDF";
+                        arreteContent = "Arrêté : <a href='" + urlPdf + "' target='_blank' class='lien-arrete'>" + numeroLabel + "</a>";
                 } else {
-                    document.getElementById("arreteCell").innerHTML = "Arrêté : " + numeroArrete;
+                    arreteContent = "Arrêté : " + numeroArrete;
                 }
+
+                if (urlPdfCadre !== '') {
+                        arreteContent += "<br/><a href='" + urlPdfCadre + "' target='_blank' class='lien-arrete'>Arrêté cadre</a>";
+                }
+
+                document.getElementById("arreteCell").innerHTML = arreteContent;
             </script>
         </td>
 	</tr>

--- a/desktop/js/propluvia.js
+++ b/desktop/js/propluvia.js
@@ -193,10 +193,11 @@ var propluviaUsageFilterManager = {
       return;
     }
     $container.empty();
+    var storedKeys = $.isArray(selectedKeys) ? selectedKeys : [];
     if (!options.length) {
       var infoMessage = isInitial ? 'La liste des usages sera disponible après un premier rafraîchissement des données.' : "Aucun usage n\'a été trouvé pour cet équipement.";
       $container.append($('<div class="alert alert-info"></div>').text(infoMessage));
-      this.syncHiddenFromCheckboxes(true, selectedKeys);
+      this.syncHiddenFromCheckboxes(true, storedKeys);
       return;
     }
     var lastThematique = null;
@@ -208,18 +209,34 @@ var propluviaUsageFilterManager = {
         $container.append($heading);
         lastThematique = thematique;
       }
-      var key = option.key;
-      if (!key) {
+      var keys = [];
+      if ($.isArray(option.keys)) {
+        for (var k = 0; k < option.keys.length; k++) {
+          var candidate = option.keys[k];
+          if (typeof candidate === 'string' || typeof candidate === 'number') {
+            var normalized = $.trim(String(candidate));
+            if (normalized !== '' && keys.indexOf(normalized) === -1) {
+              keys.push(normalized);
+            }
+          }
+        }
+      }
+      if (!keys.length && option.key) {
+        keys.push(String(option.key));
+      }
+      if (!keys.length) {
         continue;
       }
-      var $label = $('<label class="checkbox-inline usage-filter-option"></label>');
-      var $checkbox = $('<input type="checkbox" class="usage-filter-checkbox" />').attr('data-usage-key', key);
+      var displayKey = option.displayKey || keys[0];
+      var checkboxId = 'usage-filter-' + displayKey;
+      var $label = $('<label class="checkbox-inline usage-filter-option"></label>').attr('for', checkboxId);
+      var $checkbox = $('<input type="checkbox" class="usage-filter-checkbox" />').attr('id', checkboxId).attr('data-usage-keys', keys.join(','));
       $label.append($checkbox);
-      var nom = option.nom || key;
+      var nom = option.nom || keys[0];
       $label.append(document.createTextNode(' ' + nom));
       $container.append($label);
     }
-    this.applySelection(selectedKeys);
+    this.applySelection(storedKeys);
   },
   applySelection: function (selectedKeys) {
     var $container = $('#usageFilterCheckboxes');
@@ -227,12 +244,33 @@ var propluviaUsageFilterManager = {
       return;
     }
     var hasStoredSelection = $.isArray(selectedKeys) && selectedKeys.length > 0;
+    var selectedMap = {};
+    if (hasStoredSelection) {
+      for (var i = 0; i < selectedKeys.length; i++) {
+        var selectedKey = $.trim(String(selectedKeys[i]));
+        if (selectedKey !== '') {
+          selectedMap[selectedKey] = true;
+        }
+      }
+    }
     $container.find('.usage-filter-checkbox').each(function () {
-      var key = $(this).attr('data-usage-key');
+      var $checkbox = $(this);
+      var optionKeys = propluviaUsageFilterManager.parseKeys($checkbox.attr('data-usage-keys'));
+      if (!optionKeys.length) {
+        $checkbox.prop('checked', false);
+        return;
+      }
       if (hasStoredSelection) {
-        $(this).prop('checked', selectedKeys.indexOf(key) !== -1);
+        var shouldCheck = false;
+        for (var j = 0; j < optionKeys.length; j++) {
+          if (selectedMap[optionKeys[j]]) {
+            shouldCheck = true;
+            break;
+          }
+        }
+        $checkbox.prop('checked', shouldCheck);
       } else {
-        $(this).prop('checked', true);
+        $checkbox.prop('checked', true);
       }
     });
     this.syncHiddenFromCheckboxes(true, selectedKeys);
@@ -243,20 +281,38 @@ var propluviaUsageFilterManager = {
     if ($container.length === 0 || $hidden.length === 0) {
       return;
     }
-    var checkedKeys = [];
-    $container.find('.usage-filter-checkbox:checked').each(function () {
-      checkedKeys.push($(this).attr('data-usage-key'));
+    var initialArray = $.isArray(initialKeys) ? initialKeys : [];
+    var allKeysMap = {};
+    var checkedKeysMap = {};
+    $container.find('.usage-filter-checkbox').each(function () {
+      var $checkbox = $(this);
+      var keys = propluviaUsageFilterManager.parseKeys($checkbox.attr('data-usage-keys'));
+      if (!keys.length) {
+        return;
+      }
+      var isChecked = $checkbox.prop('checked');
+      for (var i = 0; i < keys.length; i++) {
+        var key = keys[i];
+        if (key === '') {
+          continue;
+        }
+        allKeysMap[key] = true;
+        if (isChecked) {
+          checkedKeysMap[key] = true;
+        }
+      }
     });
-    var totalCheckboxes = $container.find('.usage-filter-checkbox').length;
-    if (totalCheckboxes === 0) {
+    var allKeys = Object.keys(allKeysMap);
+    var checkedKeys = Object.keys(checkedKeysMap);
+    if (allKeys.length === 0) {
       $hidden.value('');
       return;
     }
-    if (isInitial === true && (!$.isArray(initialKeys) || initialKeys.length === 0) && checkedKeys.length === totalCheckboxes) {
+    if (isInitial === true && initialArray.length === 0 && checkedKeys.length === allKeys.length) {
       $hidden.value('');
       return;
     }
-    if (checkedKeys.length === totalCheckboxes) {
+    if (checkedKeys.length === allKeys.length) {
       $hidden.value('');
     } else {
       $hidden.value(checkedKeys.join(','));
@@ -277,6 +333,22 @@ var propluviaUsageFilterManager = {
       var key = $.trim(parts[i]);
       if (key !== '') {
         keys.push(key);
+      }
+    }
+    return keys;
+  },
+  parseKeys: function (raw) {
+    var keys = [];
+    if (typeof raw !== 'string' || raw === '') {
+      return keys;
+    }
+    var parts = raw.split(',');
+    for (var i = 0; i < parts.length; i++) {
+      var key = $.trim(parts[i]);
+      if (key !== '') {
+        if (keys.indexOf(key) === -1) {
+          keys.push(key);
+        }
       }
     }
     return keys;

--- a/desktop/js/propluvia.js
+++ b/desktop/js/propluvia.js
@@ -145,3 +145,180 @@ function addCmdToTable(_cmd) {
         })*/
     }
 }
+
+var propluviaUsageFilterManager = {
+  currentEqId: null,
+  refresh: function (force) {
+    var $eqIdInput = $('.eqLogicAttr[data-l1key=id]');
+    if ($eqIdInput.length === 0) {
+      return;
+    }
+    var eqId = $eqIdInput.value();
+    if (!eqId) {
+      this.currentEqId = null;
+      this.render([], this.getSelectedKeysFromConfig(), true);
+      return;
+    }
+    if (!force && this.currentEqId === eqId) {
+      this.applySelection(this.getSelectedKeysFromConfig());
+      return;
+    }
+    var self = this;
+    $.ajax({
+      type: 'POST',
+      url: 'plugins/propluvia/core/ajax/propluvia.ajax.php',
+      dataType: 'json',
+      data: {
+        action: 'getUsageOptions',
+        id: eqId
+      },
+      error: function () {
+        self.renderError("Impossible de récupérer la liste des usages. Veuillez rafraîchir l'équipement.");
+      },
+      success: function (data) {
+        if (!data || data.state !== 'ok') {
+          var message = (data && data.result) ? data.result : "Erreur lors de la récupération des usages.";
+          self.renderError(message);
+          return;
+        }
+        self.currentEqId = eqId;
+        var options = $.isArray(data.result) ? data.result : [];
+        self.render(options, self.getSelectedKeysFromConfig(), false);
+      }
+    });
+  },
+  render: function (options, selectedKeys, isInitial) {
+    var $container = $('#usageFilterCheckboxes');
+    if ($container.length === 0) {
+      return;
+    }
+    $container.empty();
+    if (!options.length) {
+      var infoMessage = isInitial ? 'La liste des usages sera disponible après un premier rafraîchissement des données.' : "Aucun usage n\'a été trouvé pour cet équipement.";
+      $container.append($('<div class="alert alert-info"></div>').text(infoMessage));
+      this.syncHiddenFromCheckboxes(true, selectedKeys);
+      return;
+    }
+    var lastThematique = null;
+    for (var i = 0; i < options.length; i++) {
+      var option = options[i];
+      var thematique = option.thematique || '';
+      if (thematique !== lastThematique) {
+        var $heading = $('<div class="usage-filter-heading"></div>').text(thematique !== '' ? thematique : 'Autres usages');
+        $container.append($heading);
+        lastThematique = thematique;
+      }
+      var key = option.key;
+      if (!key) {
+        continue;
+      }
+      var $label = $('<label class="checkbox-inline usage-filter-option"></label>');
+      var $checkbox = $('<input type="checkbox" class="usage-filter-checkbox" />').attr('data-usage-key', key);
+      $label.append($checkbox);
+      var nom = option.nom || key;
+      $label.append(document.createTextNode(' ' + nom));
+      $container.append($label);
+    }
+    this.applySelection(selectedKeys);
+  },
+  applySelection: function (selectedKeys) {
+    var $container = $('#usageFilterCheckboxes');
+    if ($container.length === 0) {
+      return;
+    }
+    var hasStoredSelection = $.isArray(selectedKeys) && selectedKeys.length > 0;
+    $container.find('.usage-filter-checkbox').each(function () {
+      var key = $(this).attr('data-usage-key');
+      if (hasStoredSelection) {
+        $(this).prop('checked', selectedKeys.indexOf(key) !== -1);
+      } else {
+        $(this).prop('checked', true);
+      }
+    });
+    this.syncHiddenFromCheckboxes(true, selectedKeys);
+  },
+  syncHiddenFromCheckboxes: function (isInitial, initialKeys) {
+    var $container = $('#usageFilterCheckboxes');
+    var $hidden = $('#usageFilterIds');
+    if ($container.length === 0 || $hidden.length === 0) {
+      return;
+    }
+    var checkedKeys = [];
+    $container.find('.usage-filter-checkbox:checked').each(function () {
+      checkedKeys.push($(this).attr('data-usage-key'));
+    });
+    var totalCheckboxes = $container.find('.usage-filter-checkbox').length;
+    if (totalCheckboxes === 0) {
+      $hidden.value('');
+      return;
+    }
+    if (isInitial === true && (!$.isArray(initialKeys) || initialKeys.length === 0) && checkedKeys.length === totalCheckboxes) {
+      $hidden.value('');
+      return;
+    }
+    if (checkedKeys.length === totalCheckboxes) {
+      $hidden.value('');
+    } else {
+      $hidden.value(checkedKeys.join(','));
+    }
+  },
+  getSelectedKeysFromConfig: function () {
+    var $hidden = $('#usageFilterIds');
+    if ($hidden.length === 0) {
+      return [];
+    }
+    var raw = $hidden.value();
+    if (typeof raw !== 'string' || raw === '') {
+      return [];
+    }
+    var parts = raw.split(',');
+    var keys = [];
+    for (var i = 0; i < parts.length; i++) {
+      var key = $.trim(parts[i]);
+      if (key !== '') {
+        keys.push(key);
+      }
+    }
+    return keys;
+  },
+  renderError: function (message) {
+    var $container = $('#usageFilterCheckboxes');
+    if ($container.length === 0) {
+      return;
+    }
+    $container.empty().append($('<div class="alert alert-danger"></div>').text(message));
+  }
+};
+
+$(document).on('change', '.eqLogicAttr[data-l1key=id]', function () {
+  propluviaUsageFilterManager.currentEqId = null;
+  propluviaUsageFilterManager.refresh(true);
+});
+
+$(document).on('click', '#usageFilterReload', function (e) {
+  e.preventDefault();
+  propluviaUsageFilterManager.currentEqId = null;
+  propluviaUsageFilterManager.refresh(true);
+});
+
+$(document).on('click', '#usageFilterSelectAll', function (e) {
+  e.preventDefault();
+  var $container = $('#usageFilterCheckboxes');
+  $container.find('.usage-filter-checkbox').prop('checked', true);
+  propluviaUsageFilterManager.syncHiddenFromCheckboxes(false);
+});
+
+$(document).on('click', '#usageFilterClear', function (e) {
+  e.preventDefault();
+  var $container = $('#usageFilterCheckboxes');
+  $container.find('.usage-filter-checkbox').prop('checked', false);
+  propluviaUsageFilterManager.syncHiddenFromCheckboxes(false);
+});
+
+$(document).on('change', '#usageFilterCheckboxes .usage-filter-checkbox', function () {
+  propluviaUsageFilterManager.syncHiddenFromCheckboxes(false);
+});
+
+$(document).ready(function () {
+  propluviaUsageFilterManager.refresh(false);
+});

--- a/desktop/php/propluvia.php
+++ b/desktop/php/propluvia.php
@@ -145,7 +145,7 @@ $eqLogics = eqLogic::byType($plugin->getId());
                                 </div>
                         	</div>
                             <div class="form-group">
-                            	<label class="col-sm-4 control-label">{{Type éditorial}}</label>
+                                <label class="col-sm-4 control-label">{{Type éditorial}}</label>
                                 <div class="col-sm-3">
                                   <select class="form-control eqLogicAttr" data-l1key="configuration" data-l2key="typeInfo">
                                     <option value="part">{{Particulier}}</option>
@@ -153,10 +153,24 @@ $eqLogics = eqLogic::byType($plugin->getId());
                                     <option value="">{{Tout}}</option>
                                   </select>
                                 </div>
-                        	</div>
-						</div>
+                                </div>
+                            <div class="form-group">
+                                <label class="col-sm-4 control-label">{{Usages affichés}}</label>
+                                <div class="col-sm-6" id="usageFilterCheckboxes">
+                                        <div class="alert alert-info">{{La liste des usages sera disponible après un premier rafraîchissement des données.}}</div>
+                                </div>
+                                <div class="col-sm-2">
+                                        <div class="btn-group" style="margin-bottom:5px;">
+                                                <a class="btn btn-default btn-sm" id="usageFilterSelectAll">{{Tout sélectionner}}</a>
+                                                <a class="btn btn-default btn-sm" id="usageFilterClear">{{Tout décocher}}</a>
+                                        </div>
+                                        <a class="btn btn-default btn-sm" id="usageFilterReload">{{Actualiser la liste}}</a>
+                                </div>
+                                <input type="hidden" class="eqLogicAttr" data-l1key="configuration" data-l2key="usageFilterIds" id="usageFilterIds" />
+                                </div>
+                                                </div>
 
-						<!-- Partie droite de l'onglet "Équipement" -->
+                                                <!-- Partie droite de l'onglet "Équipement" -->
 						<div class="col-lg-6">
 							<legend><i class="fas fa-info"></i> {{Informations}}</legend>
 							

--- a/desktop/php/propluvia.php
+++ b/desktop/php/propluvia.php
@@ -20,8 +20,8 @@ $eqLogics = eqLogic::byType($plugin->getId());
 .usage-filter-wrapper {
   width: 100%;
   min-height: 180px;
-  border: 1px solid #d9d9d9;
-  background-color: #fff;
+  border: none;
+  background-color: transparent;
   padding: 14px 18px;
 }
 
@@ -187,17 +187,18 @@ $eqLogics = eqLogic::byType($plugin->getId());
                                 <a href="http://public.opendatasoft.com/explore/dataset/correspondance-code-insee-code-postal/table/?flg=fr&location=9,45.71673,3.13522&basemap=jawg.light" target="_blank">Liste des codes INSEE</a>
 							</div>
                             <div class="form-group">
-                            	<label class="col-sm-4 control-label">{{Restrictions spécifiques}}</label>
+                                <label class="col-sm-4 control-label">{{Restrictions spécifiques}}</label>
                                 <div class="col-sm-3">
                                   <select class="form-control eqLogicAttr" data-l1key="configuration" data-l2key="typeRestriction">
-                                    <option value="sup">{{Eaux superficielles}}</option>
-                                    <option value="sou">{{Eaux souterraines}}</option>
-                                    <option value="all">{{Les deux}}</option>
+                                    <option value="aep">{{Du robinet (AEP)}}</option>
+                                    <option value="sup">{{D'un cours d'eau ou d'une rivière (SUP)}}</option>
+                                    <option value="sou">{{Des nappes (puits ou forage) (SOU)}}</option>
+                                    <option value="all">{{Toutes les ressources}}</option>
                                   </select>
                                 </div>
-                        	</div>
+                                </div>
                             <div class="form-group">
-                                <label class="col-sm-4 control-label">{{Type d'usage}}</label>
+                                <label class="col-sm-4 control-label">{{Profil}}</label>
                                 <div class="col-sm-3">
                                   <select class="form-control eqLogicAttr" data-l1key="configuration" data-l2key="typeInfo">
                                     <option value="particulier">{{Particulier}}</option>

--- a/desktop/php/propluvia.php
+++ b/desktop/php/propluvia.php
@@ -145,28 +145,31 @@ $eqLogics = eqLogic::byType($plugin->getId());
                                 </div>
                         	</div>
                             <div class="form-group">
-                                <label class="col-sm-4 control-label">{{Type éditorial}}</label>
+                                <label class="col-sm-4 control-label">{{Type d'usage}}</label>
                                 <div class="col-sm-3">
                                   <select class="form-control eqLogicAttr" data-l1key="configuration" data-l2key="typeInfo">
-                                    <option value="part">{{Particulier}}</option>
-                                    <option value="pro">{{Profesionnel}}</option>
-                                    <option value="">{{Tout}}</option>
+                                    <option value="particulier">{{Particulier}}</option>
+                                    <option value="entreprise">{{Entreprise}}</option>
+                                    <option value="collectivites">{{Collectivités}}</option>
+                                    <option value="exploitation_agricole">{{Exploitation agricole}}</option>
                                   </select>
                                 </div>
                                 </div>
                             <div class="form-group">
                                 <label class="col-sm-4 control-label">{{Usages affichés}}</label>
-                                <div class="col-sm-6" id="usageFilterCheckboxes">
-                                        <div class="alert alert-info">{{La liste des usages sera disponible après un premier rafraîchissement des données.}}</div>
-                                </div>
-                                <div class="col-sm-2">
-                                        <div class="btn-group" style="margin-bottom:5px;">
-                                                <a class="btn btn-default btn-sm" id="usageFilterSelectAll">{{Tout sélectionner}}</a>
-                                                <a class="btn btn-default btn-sm" id="usageFilterClear">{{Tout décocher}}</a>
+                                <div class="col-sm-8">
+                                        <div id="usageFilterCheckboxes" style="min-height: 180px; max-height: 360px; overflow-y: auto; border: 1px solid #d9d9d9; padding: 10px; background-color: #fff;">
+                                                <div class="alert alert-info">{{La liste des usages sera disponible après un premier rafraîchissement des données.}}</div>
                                         </div>
-                                        <a class="btn btn-default btn-sm" id="usageFilterReload">{{Actualiser la liste}}</a>
+                                        <input type="hidden" class="eqLogicAttr" data-l1key="configuration" data-l2key="usageFilterIds" id="usageFilterIds" />
+                                        <div class="usage-filter-actions" style="margin-top:10px; display:flex; flex-wrap:wrap; gap:5px;">
+                                                <div class="btn-group" role="group">
+                                                        <a class="btn btn-default btn-sm" id="usageFilterSelectAll">{{Tout sélectionner}}</a>
+                                                        <a class="btn btn-default btn-sm" id="usageFilterClear">{{Tout décocher}}</a>
+                                                </div>
+                                                <a class="btn btn-default btn-sm" id="usageFilterReload">{{Actualiser la liste}}</a>
+                                        </div>
                                 </div>
-                                <input type="hidden" class="eqLogicAttr" data-l1key="configuration" data-l2key="usageFilterIds" id="usageFilterIds" />
                                 </div>
                                                 </div>
 

--- a/desktop/php/propluvia.php
+++ b/desktop/php/propluvia.php
@@ -8,6 +8,58 @@ sendVarToJS('eqType', $plugin->getId());
 $eqLogics = eqLogic::byType($plugin->getId());
 ?>
 
+<style>
+#usageFilterCheckboxes.usage-filter-box {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  grid-column-gap: 20px;
+  grid-row-gap: 8px;
+  margin: 0;
+}
+
+.usage-filter-wrapper {
+  width: 100%;
+  min-height: 180px;
+  border: 1px solid #d9d9d9;
+  background-color: #fff;
+  padding: 14px 18px;
+}
+
+#usageFilterCheckboxes .usage-filter-heading {
+  grid-column: 1 / -1;
+  font-weight: 600;
+  margin: 6px 0 2px;
+}
+
+#usageFilterCheckboxes .usage-filter-option {
+  display: flex;
+  align-items: flex-start;
+  white-space: normal;
+  margin: 0;
+}
+
+#usageFilterCheckboxes .usage-filter-option input {
+  margin-top: 3px;
+  margin-right: 6px;
+}
+
+#usageFilterCheckboxes .alert {
+  grid-column: 1 / -1;
+  margin: 0;
+}
+
+.usage-filter-actions {
+  margin-top: 10px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 5px;
+}
+
+.usage-filter-actions .btn-group {
+  display: inline-flex;
+}
+</style>
+
 <div class="row row-overflow">
 	<!-- Page d'accueil du plugin -->
 	<div class="col-xs-12 eqLogicThumbnailDisplay">
@@ -158,11 +210,13 @@ $eqLogics = eqLogic::byType($plugin->getId());
                             <div class="form-group">
                                 <label class="col-sm-4 control-label">{{Usages affichés}}</label>
                                 <div class="col-sm-8">
-                                        <div id="usageFilterCheckboxes" style="min-height: 180px; max-height: 360px; overflow-y: auto; border: 1px solid #d9d9d9; padding: 10px; background-color: #fff;">
-                                                <div class="alert alert-info">{{La liste des usages sera disponible après un premier rafraîchissement des données.}}</div>
+                                        <div class="usage-filter-wrapper">
+                                                <div id="usageFilterCheckboxes" class="usage-filter-box">
+                                                        <div class="alert alert-info">{{La liste des usages sera disponible après un premier rafraîchissement des données.}}</div>
+                                                </div>
                                         </div>
                                         <input type="hidden" class="eqLogicAttr" data-l1key="configuration" data-l2key="usageFilterIds" id="usageFilterIds" />
-                                        <div class="usage-filter-actions" style="margin-top:10px; display:flex; flex-wrap:wrap; gap:5px;">
+                                        <div class="usage-filter-actions">
                                                 <div class="btn-group" role="group">
                                                         <a class="btn btn-default btn-sm" id="usageFilterSelectAll">{{Tout sélectionner}}</a>
                                                         <a class="btn btn-default btn-sm" id="usageFilterClear">{{Tout décocher}}</a>


### PR DESCRIPTION
## Summary
- replace the deprecated Propluvia endpoint with Vigieau API calls
- adapt restriction parsing, severity mapping, and editorial content extraction to the new schema
- keep widget commands updated when data is unavailable or filtered by restriction type

## Testing
- php -l core/class/propluvia.class.php

------
https://chatgpt.com/codex/tasks/task_e_68e92b7f744c83309cbb0c5b71ec27a4